### PR TITLE
fix(gha): Use correctjob reference in build-docker-image workflow outputs

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -88,10 +88,10 @@ on:
     outputs:
       docker_build_version:
         description: "Docker image version built"
-        value: ${{ jobs.docker.outputs.docker_build_version }}
+        value: ${{ jobs.build.outputs.docker_build_version }}
       docker_debug_version:
         description: "Docker debug image version built"
-        value: ${{ jobs.docker.outputs.docker_debug_version }}
+        value: ${{ jobs.build.outputs.docker_debug_version }}
 concurrency:
   group: build-docker-${{ github.repository }}-${{ inputs.source_branch }}-${{ inputs.architecture }}
   cancel-in-progress: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build workflow to reference version outputs from the correct job source.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->