### PR TITLE
Add flag to disable scan vulnerability failures

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -76,6 +76,11 @@ on:
         required: false
         type: string
         description: "Kubernetes label selector for the deployment to restart in staging"
+      fail_on_scan_vulnerabilities:
+        required: false
+        type: boolean
+        description: "Whether to fail the build if vulnerabilities are found during the scan"
+        default: true
     secrets:
       gcp_service_account:
         required: true
@@ -231,11 +236,16 @@ jobs:
           fi
       - name: Scan vulnerabilities with Trivy
         run: |
+          if [ "${{ inputs.fail_on_scan_vulnerabilities }}" = "true" ]; then
+            EXIT_CODE_OPTION="--exit-code 1"
+          else
+            EXIT_CODE_OPTION=""
+          fi
           trivy image \
             --format sarif \
             --output "trivy-results-${{ inputs.architecture }}.sarif" \
             --severity HIGH,CRITICAL \
-            --exit-code 1 \
+            $EXIT_CODE_OPTION \
             "${{ steps.docker.outputs.gcp_docker_image }}"
       - name: Upload Trivy vulnerabilities to GitHub Security
         uses: github/codeql-action/upload-sarif@d3ced5c96c16c4332e2a61eb6f3649d6f1b20bb8 # v3.31.5

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -78,9 +78,9 @@ on:
         description: "Kubernetes label selector for the deployment to restart in staging"
       fail_on_scan_vulnerabilities:
         required: false
-        type: boolean
+        type: string
         description: "Whether to fail the build if vulnerabilities are found during the scan"
-        default: true
+        default: "true"
     secrets:
       gcp_service_account:
         required: true

--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ jobs:
 - `binary` (Required): The name of the binary to output.
 - `timeout_minutes` (Optional): Timeout for the job in minutes (Default: `60`).
 - `runner` (Required): The runner label to use for the job.
-- `deployment_namespace`: Kubernetes namespace for the deployment to restart in staging
-- `deployment_label_selector`: Kubernetes label selector for the deployment to restart in staging
-- `fail_on_scan_vulnerabilities`: Whether to fail the build if vulnerabilities are found during the scan (Default: `true`)
 
 **Secrets:**
 - `gcp_service_account` (Required): Google Cloud Service Account with permissions to upload artifacts.
@@ -115,6 +112,7 @@ jobs:
 - `runner` (Optional): Runner to use for the job (Default: `self-hosted-hoprnet-bigger`).
 - `deployment_namespace` (Optional): Kubernetes namespace for the deployment to restart in staging.
 - `deployment_label_selector` (Optional): Kubernetes label selector for the deployment to restart in staging.
+- `fail_on_scan_vulnerabilities`: Whether to fail the build if vulnerabilities are found during the scan (Default: `true`)
 
 **Secrets:**
 - `gcp_service_account` (Required): Google Cloud Service Account with permissions to upload artifacts.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ jobs:
 - `binary` (Required): The name of the binary to output.
 - `timeout_minutes` (Optional): Timeout for the job in minutes (Default: `60`).
 - `runner` (Required): The runner label to use for the job.
+- `deployment_namespace`: Kubernetes namespace for the deployment to restart in staging
+- `deployment_label_selector`: Kubernetes label selector for the deployment to restart in staging
+- `fail_on_scan_vulnerabilities`: Whether to fail the build if vulnerabilities are found during the scan (Default: `true`)
 
 **Secrets:**
 - `gcp_service_account` (Required): Google Cloud Service Account with permissions to upload artifacts.

--- a/actions/setup-gcp/action.yaml
+++ b/actions/setup-gcp/action.yaml
@@ -45,7 +45,7 @@ runs:
           shell: bash
           run: |
             CLUSTER_NAME=$(echo "cluster-${{ inputs.project }}" | sed 's/hopr-//g')
-            echo "cluster_name=$CLUSTER_NAME" >> $GITHUB_OUTPUT
+            echo "cluster_name=$CLUSTER_NAME" | tee -a "$GITHUB_OUTPUT"
         - name: Connect to GKE
           uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
           if: inputs.login_gke == 'true'


### PR DESCRIPTION
The current docker build workflow fails when the docker vulnerability scan finds a high or critical vulnerability. Some projects need time to analyze the vulnerability or there is no alternative than to accept the vulnerability.

This PR adds a flag to avoid blocking the projects but still reporting the vulnerability scan analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable vulnerability scanning behavior for Docker image builds; builds can now optionally proceed when vulnerabilities are detected during scans.

* **Documentation**
  * Updated workflow documentation with new configuration parameters for deployment staging and vulnerability scanning options.

* **Chores**
  * Minor workflow utility improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->