### PR TITLE
Fix download-artifact-registry action

### DIFF
--- a/actions/download-artifact-registry/action.yaml
+++ b/actions/download-artifact-registry/action.yaml
@@ -34,6 +34,7 @@ runs:
         shell: bash
         id: artifacts
         run: |
+          set -x
           mkdir -p "${{ inputs.destination }}"
           if ! files=$(gcloud artifacts files list \
             --project="${{ inputs.project }}" \

--- a/actions/download-artifact-registry/action.yaml
+++ b/actions/download-artifact-registry/action.yaml
@@ -50,7 +50,7 @@ runs:
             echo "Error: No files found for package ${{ inputs.package }} version ${{ inputs.version }}"
             exit 1
           fi
-          IFS=$'\n' read -rd '' -a files_array <<<"$files"
+          IFS=$'\n' read -rd '' -a files_array <<<"$files" || true
           for file in "${files_array[@]}"; do
             if ! gcloud artifacts generic download \
               --project="${{ inputs.project }}" \

--- a/actions/download-artifact-registry/action.yaml
+++ b/actions/download-artifact-registry/action.yaml
@@ -52,6 +52,8 @@ runs:
           fi
           IFS=$'\n' read -rd '' -a files_array <<<"$files" || true
           for file in "${files_array[@]}"; do
+            # Extract the filename from the full resource path (after the last ':')
+            filename="${file##*:}"
             if ! gcloud artifacts generic download \
               --project="${{ inputs.project }}" \
               --location="${{ inputs.region }}" \
@@ -59,8 +61,8 @@ runs:
               --package="${{ inputs.package }}" \
               --version="${{ inputs.version }}" \
               --destination="${{ inputs.destination }}" \
-              "${file}"; then
-              echo "Error: Failed to download ${file}"
+              --name="${filename}"; then
+              echo "Error: Failed to download ${filename}"
               exit 1
             fi
           done

--- a/actions/download-artifact-registry/action.yaml
+++ b/actions/download-artifact-registry/action.yaml
@@ -34,7 +34,6 @@ runs:
         shell: bash
         id: artifacts
         run: |
-          set -x
           mkdir -p "${{ inputs.destination }}"
           if ! files=$(gcloud artifacts files list \
             --project="${{ inputs.project }}" \


### PR DESCRIPTION
The action `download-artifact-registry@download-artifact-registry-v1` had 2 issues:
- The transformation of files into an array was incorrect and had to add a fallback instruction to avoid premature exit
- The gcloud command was incorrect and required the parameter `--name` and it's value formatted accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of file reading with graceful error handling.
  * Enhanced error messaging for clearer feedback.

* **New Features**
  * Added output listing all successfully downloaded files.

* **Refactor**
  * Optimized per-file download operations for better reliability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->