### PR TITLE
Unify docker-build-image and docker-manifest in single workflow

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -130,7 +130,7 @@ jobs:
           path: ${{ github.workspace }}/artifacts/${{ inputs.binary }}-${{ inputs.architecture}}.sha256
       - name: Setup GCP
         if: needs.build.outputs.publish_artifact == 'true'
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ secrets.gcp_service_account }}
           install_sdk: "true"

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -85,7 +85,7 @@ jobs:
           cachix_auth_token: "${{ secrets.cachix_auth_token }}"
       - name: Updates build version
         id: version
-        uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v1
+        uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v2
         with:
           file: "${{ inputs.build_file }}"
           version_type: "${{ inputs.version_type }}"

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -52,7 +52,7 @@ on:
       gpg_private_key:
         required: true
 concurrency:
-  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-${{ inputs.architecture }}
+  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-${{ inputs.architecture }}-binary
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -1,7 +1,7 @@
 #################################################################################
 # Pipeline to build binaries
 #################################################################################
-name: Build binaries
+name: Build binary
 
 on:
   workflow_call:
@@ -28,10 +28,6 @@ on:
         required: true
         type: string
         description: "Command to build the binary"
-      build_debug_command:
-        required: false
-        type: string
-        description: "Additional build debug flavor to use"
       binary:
         required: true
         type: string
@@ -91,12 +87,11 @@ jobs:
           version_type: "${{ inputs.version_type }}"
           architecture: "${{ inputs.architecture }}"
       - name: Build binary ${{ inputs.architecture }}
+        shell: bash
         run: |
           ${{ inputs.build_command }}
           mkdir -p ./artifacts
           cp ./result/bin/${{ inputs.binary }} ${{ github.workspace }}/artifacts/${{ inputs.binary }}-${{ inputs.architecture }}
-        env:
-          architecture: ${{ inputs.architecture }}
       - name: Upload binary ${{ inputs.binary }}-${{ inputs.architecture }}
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -40,6 +40,11 @@ on:
       runner:
         required: true
         type: string
+      enabled:
+        required: false
+        type: boolean
+        default: true
+        description: "Whether to run this job"
     secrets:
       gcp_service_account:
         required: true
@@ -57,6 +62,7 @@ permissions:
 jobs:
   build:
     name: Build
+    if: inputs.enabled
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
@@ -93,7 +99,7 @@ jobs:
           mkdir -p ./artifacts
           cp ./result/bin/${{ inputs.binary }} ${{ github.workspace }}/artifacts/${{ inputs.binary }}-${{ inputs.architecture }}
       - name: Upload binary ${{ inputs.binary }}-${{ inputs.architecture }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ inputs.binary }}-${{ inputs.architecture }}
           path: ${{ github.workspace }}/artifacts/${{ inputs.binary }}-${{ inputs.architecture }}
@@ -104,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download binary ${{ inputs.binary }}-${{ inputs.architecture }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: ${{ inputs.binary }}-${{ inputs.architecture }}
           path: ${{ github.workspace }}/artifacts
@@ -114,12 +120,12 @@ jobs:
           file: ${{ github.workspace }}/artifacts/${{ inputs.binary }}-${{ inputs.architecture }}
           gpg_private_key: ${{ secrets.gpg_private_key }}
       - name: Upload ${{ inputs.binary }}-${{ inputs.architecture }} signed binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ inputs.binary }}-${{ inputs.architecture}}.asc
           path: ${{ github.workspace }}/artifacts/${{ inputs.binary }}-${{ inputs.architecture}}.asc
       - name: Upload ${{ inputs.binary }}-${{ inputs.architecture }} sha256 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ inputs.binary }}-${{ inputs.architecture}}.sha256
           path: ${{ github.workspace }}/artifacts/${{ inputs.binary }}-${{ inputs.architecture}}.sha256

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -124,7 +124,7 @@ jobs:
           ref: ${{ inputs.source_branch }}
       - name: Updates build version
         id: version
-        uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v1
+        uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v2
         with:
           file: "${{ inputs.build_file }}"
           version_type: "${{ inputs.version_type }}"

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -98,7 +98,7 @@ on:
         description: "Docker debug image version built"
         value: ${{ jobs.build.outputs.docker_debug_version }}
 concurrency:
-  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-${{ inputs.architecture }}-${{ inputs.docker_image_name }}
+  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-${{ inputs.architecture }}-docker
   cancel-in-progress: true
 jobs:
   build:

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -304,7 +304,7 @@ jobs:
           path: test.logs
           retention-days: 7
   deploy:
-    name: Deploy
+    name: Deploy Hoprnet
     needs: build
     if: (needs.build.outputs.deploy_staging == 'true' || (vars.DEPLOY_STAGING_MERGED_PR == 'true' && inputs.version_type == 'pr')) && (inputs.deployment_namespace != '' && inputs.deployment_label_selector != '')
     runs-on: self-hosted-hoprnet-small

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -131,7 +131,7 @@ jobs:
           architecture: "${{ inputs.architecture }}"
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ secrets.gcp_service_account }}
           login_artifact_registry: 'true'
@@ -214,7 +214,7 @@ jobs:
           sudo mv cosign /usr/local/bin/cosign
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ secrets.gcp_service_account }}
           login_artifact_registry: 'true'
@@ -311,7 +311,7 @@ jobs:
     steps:
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ secrets.gcp_service_account }}
           install_sdk: 'true'

--- a/.github/workflows/build-docker-manifest.yaml
+++ b/.github/workflows/build-docker-manifest.yaml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ secrets.gcp_service_account }}
           login_artifact_registry: 'true'

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -22,11 +22,6 @@ on:
         description: 'JSON string for the matrix strategy. Must include keys: runner, architecture, build_command, build_debug_command (optional), smoke_test_command (optional)'
         required: true
         type: string
-      # architecture:
-      #   required: false
-      #   type: string
-      #   default: "x86_64-linux"
-      #   description: "Target architecture for the docker image"
       cachix_cache_name:
         required: true
         type: string
@@ -36,18 +31,6 @@ on:
         type: string
         default: "Cargo.toml"
         description: "File to extract version from"
-      # build_command:
-      #   required: true
-      #   type: string
-      #   description: "Command to build the docker image"
-      # build_debug_command:
-      #   required: false
-      #   type: string
-      #   description: "Additional build debug flavor to use"
-      # smoke_test_command:
-      #   required: false
-      #   type: string
-      #   description: "Command to run smoke tests against the built image"
       docker_image_name:
         required: true
         type: string
@@ -67,11 +50,6 @@ on:
         type: number
         default: 60
         description: "Timeout for the job in minutes"
-      # runner:
-      #   required: false
-      #   type: string
-      #   description: "Runner to use for the job"
-      #   default: "self-hosted-hoprnet-bigger"
       deployment_namespace:
         required: false
         type: string
@@ -102,12 +80,15 @@ on:
         description: "Docker debug image version built"
         value: ${{ jobs.build.outputs.docker_debug_version }}
 concurrency:
-  group: build-docker-${{ github.repository }}-${{ inputs.source_branch }}-${{ fromJSON(inputs.build_matrix).architecture }}
+  group: build-docker-${{ github.repository }}-${{ inputs.source_branch }}
   cancel-in-progress: true
 jobs:
   build:
     name: Build
-    runs-on: ${{ fromJSON(inputs.build_matrix).runner }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include: ${{ fromJSON(inputs.build_matrix) }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
       docker_build_version_platform: ${{ steps.version.outputs.docker_build_version_platform }}
@@ -115,6 +96,7 @@ jobs:
       docker_debug_version: ${{ steps.version.outputs.docker_debug_version }}
       deploy_staging: ${{ steps.version.outputs.deploy_staging }}
       publish_docker_hub: ${{ steps.docker_hub.outputs.publish_docker_hub }}
+      docker_platform: ${{ steps.version.outputs.docker_platform }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -132,7 +114,7 @@ jobs:
         with:
           file: "${{ inputs.build_file }}"
           version_type: "${{ inputs.version_type }}"
-          architecture: "${{ fromJSON(inputs.build_matrix).architecture }}"
+          architecture: "${{ matrix.architecture }}"
       - name: Setup GCP
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
@@ -145,24 +127,14 @@ jobs:
           cachix_cache_name: ${{ inputs.cachix_cache_name }}
           cachix_auth_token: "${{ secrets.cachix_auth_token }}"
       - name: Build docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
-        run: ${{ fromJSON(inputs.build_matrix).build_command }}
+        run: ${{ matrix.build_command }}
         env:
           IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
-      # - name: Build staging docker image - ${{ inputs.docker_image_name }}:staging
-      #   if: steps.version.outputs.deploy_staging == 'true' && fromJSON(inputs.build_matrix).architecture == 'x86_64-linux'
-      #   run: ${{ fromJSON(inputs.build_matrix).build_command }}
-      #   env:
-      #     IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:staging
       - name: Build debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
-        if: steps.version.outputs.docker_debug_version_platform != '' && fromJSON(inputs.build_matrix).build_debug_command != ''
-        run: ${{ fromJSON(inputs.build_matrix).build_debug_command }}
+        if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
+        run: ${{ matrix.build_debug_command }}
         env:
           IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
-      # - name: Build latest docker image - ${{ inputs.docker_image_name }}:latest-${{ steps.version.outputs.docker_platform }}
-      #   if: inputs.version_type == 'pr'
-      #   run: ${{ fromJSON(inputs.build_matrix).build_command }}
-      #   env:
-      #     IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:latest-${{ steps.version.outputs.docker_platform }}
       - name: Determine DockerHub publishing condition
         id: docker_hub
         run: |
@@ -177,11 +149,6 @@ jobs:
         with:
           username: ${{ secrets.docker_hub_username }}
           password: ${{ secrets.docker_hub_token }}
-      # - name: Build docker image - DockerHub - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
-      #   if: steps.docker_hub.outputs.publish_docker_hub == 'true'
-      #   run: ${{ fromJSON(inputs.build_matrix).build_command }}
-      #   env:
-      #     IMAGE_NAME: ${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
       - name: Publish docker images
         run: |
           gcp_image_name="${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}"
@@ -189,27 +156,27 @@ jobs:
           echo "Publishing image to GCP Artifact Registry: ${gcp_image}"
           docker push "${gcp_image}"
           echo "Published image to GCP Artifact Registry: ${gcp_image}"
-          if [ "${{ steps.version.outputs.deploy_staging }}" = "true" ] && [ "${{ fromJSON(inputs.build_matrix).architecture }}" = "x86_64-linux" ]; then
+          if [[ "${{ steps.version.outputs.deploy_staging }}" == "true" && "${{ matrix.architecture }}" == "x86_64-linux" ]]; then
             staging_image="${gcp_image_name}:staging"
             echo "Publishing staging image to GCP Artifact Registry: ${staging_image}"
             docker tag "${gcp_image}" "${staging_image}"
             docker push "${staging_image}"
             echo "Published staging image to GCP Artifact Registry: ${staging_image}"
           fi
-          if [ "${{ steps.version.outputs.docker_debug_version_platform }}" != "" ] && [ "${{ fromJSON(inputs.build_matrix).build_debug_command }}" != "" ]; then
+          if [[ "${{ steps.version.outputs.docker_debug_version_platform }}" != "" && "${{ matrix.build_debug_command }}" != "" ]]; then
             debug_image="${gcp_image_name}:${{ steps.version.outputs.docker_debug_version_platform }}"
             echo "Publishing debug image to GCP Artifact Registry: ${debug_image}"
             docker push "${debug_image}"
             echo "Published debug image to GCP Artifact Registry: ${debug_image}"
           fi
-          if [ "${{ inputs.version_type }}" = "pr" ] && [ "${{ fromJSON(inputs.build_matrix).architecture }}" = "x86_64-linux" ]; then
+          if [[ "${{ inputs.version_type }}" == "pr" ]]; then
             latest_image="${gcp_image_name}:latest-${{ steps.version.outputs.docker_platform }}"
             echo "Publishing latest image to GCP Artifact Registry: ${latest_image}"
             docker tag "${gcp_image}" "${latest_image}"
             docker push "${latest_image}"
             echo "Published latest image to GCP Artifact Registry: ${latest_image}"
           fi
-          if [ "${{ steps.docker_hub.outputs.publish_docker_hub }}" = "true" ]; then
+          if [[ "${{ steps.docker_hub.outputs.publish_docker_hub }}" == "true" ]]; then
             docker_hub_image="${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}"
             echo "Publishing image to DockerHub: ${docker_hub_image}"
             docker tag "${gcp_image}" "${docker_hub_image}"
@@ -273,6 +240,9 @@ jobs:
     name: Scan
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include: ${{ fromJSON(inputs.build_matrix) }}
     permissions:
       contents: read
       id-token: write # Allows to request an identity token. Fetches an OIDC token from GitHub OAuth OIDC provider
@@ -325,15 +295,15 @@ jobs:
           fi
           trivy image \
             --format sarif \
-            --output "trivy-results-${{ fromJson(inputs.build_matrix).architecture }}.sarif" \
+            --output "trivy-results-${{ needs.build.outputs.docker_platform }}.sarif" \
             --severity HIGH,CRITICAL \
             $EXIT_CODE_OPTION \
             "${{ steps.docker.outputs.gcp_docker_image }}"
       - name: Upload Trivy vulnerabilities to GitHub Security
         uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
         with:
-          sarif_file: trivy-results-${{ fromJson(inputs.build_matrix).architecture }}.sarif
-          category: trivy-${{ fromJson(inputs.build_matrix).architecture }}
+          sarif_file: trivy-results-${{ needs.build.outputs.docker_platform }}.sarif
+          category: trivy-${{ needs.build.outputs.docker_platform }}
       - name: Generate SBOM
         run: trivy image --format cyclonedx --output "sbom.json" "${{ steps.docker.outputs.gcp_docker_image }}"
       - name: Attach SBOM to Google Artifact for attestation
@@ -359,9 +329,12 @@ jobs:
           COSIGN_YES: "true"
   smoke-test:
     name: Smoke Test
-    if: vars.RUN_DOCKER_SMOKE_TESTS == 'true' && fromJson(inputs.build_matrix).architecture == 'x86_64-linux' && fromJson(inputs.build_matrix).smoke_test_command != ''
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include: ${{ fromJSON(inputs.build_matrix) }}
+    if: vars.RUN_DOCKER_SMOKE_TESTS == 'true' && matrix.smoke_test_command != ''
     needs: build
-    runs-on: self-hosted-hoprnet-big
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -374,7 +347,8 @@ jobs:
           cachix_cache_name: ${{ inputs.cachix_cache_name }}
           cachix_auth_token: "${{ secrets.cachix_auth_token }}"
       - name: Run smoke tests
-        run: ${{ fromJson(inputs.build_matrix).smoke_test_command }} 2>&1 | tee test.logs
+        if: matrix.smoke_test_command != ''
+        run: ${{ matrix.smoke_test_command }} 2>&1 | tee test.logs
         env:
           SOURCE_IMAGE: "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ needs.build.outputs.docker_build_version_platform }}"
       - name: Upload logs on failure

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -264,13 +264,6 @@ jobs:
     steps:
       - name: Set up Docker
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
-      - name: Install Trivy
-        env:
-          TRIVY_VERSION: "0.69.1"
-        run: |
-          curl -Lo trivy.deb "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb"
-          sudo apt-get install -y ./trivy.deb
-          rm trivy.deb
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
@@ -311,31 +304,60 @@ jobs:
             docker_hub_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${docker_hub_image}" | awk -F'@' '{print $2}')
             echo "docker_hub_digest=${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}@${docker_hub_digest}" | tee -a $GITHUB_OUTPUT
           fi
-      - name: Scan vulnerabilities with Trivy
-        run: |
           if [ "${{ inputs.fail_on_scan_vulnerabilities }}" = "true" ]; then
-            EXIT_CODE_OPTION="--exit-code 1"
+            echo "trivy_exit_code=1" | tee -a $GITHUB_ENV
           else
-            EXIT_CODE_OPTION=""
+            echo "trivy_exit_code=0" | tee -a $GITHUB_ENV
           fi
-          trivy image \
-            --format sarif \
-            --output "trivy-results-${{ steps.platform.outputs.docker_platform }}.sarif" \
-            --severity HIGH,CRITICAL \
-            $EXIT_CODE_OPTION \
-            "${{ steps.docker.outputs.gcp_docker_image }}"
-      - name: Upload Trivy vulnerabilities to GitHub Security
-        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # v0.34.1
         with:
-          sarif_file: trivy-results-${{ steps.platform.outputs.docker_platform }}.sarif
-          category: trivy-${{ steps.platform.outputs.docker_platform }}
+          image-ref: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.platform.outputs.docker_build_version_platform }}
+          format: table
+          exit-code: "${{ steps.docker.outputs.trivy_exit_code }}"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "HIGH,CRITICAL"
+          output: trivy.txt
+      - name: Build PR comment body
+        run: |
+          {
+            echo "## 🔎 Trivy report"
+            echo ""
+            echo "_Updated for commit \`${{ github.event.pull_request.head.sha }}\`_"
+            echo ""
+            echo '```'
+            sed -n '1,650p' trivy.txt
+            echo '```'
+            echo ""
+          } > trivy-comment.md
+      - name: Find existing Trivy comment
+        id: find
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad #v4.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "## 🔎 Trivy report"
+
+      - name: Create or update Trivy comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 #v5.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          body-path: trivy-comment.md
+          edit-mode: replace
       - name: Generate SBOM
-        run: trivy image --format cyclonedx --output "sbom.json" "${{ steps.docker.outputs.gcp_docker_image }}"
-      - name: Attach SBOM to Google Artifact for attestation
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # v0.34.1
+        with:
+          scan-type: image
+          image-ref: ${{ steps.docker.outputs.gcp_docker_image }}
+          format: cyclonedx
+          output: sbom.json
+      - name: Attest SBOM on GCP Artifact Registry
         run: cosign attest --predicate "sbom.json" --type cyclonedx "${{ steps.docker.outputs.gcp_docker_digest }}"
         env:
           COSIGN_YES: "true"
-      - name: Attach SBOM to Google Artifact for vulnerability analysis
+      - name: Upload SBOM file to GCS Bucket for Google Artifact vulnerability analysis
         run: |
           gcloud artifacts sbom load \
             --source sbom.json \

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -360,7 +360,7 @@ jobs:
           retention-days: 7
   deploy:
     name: Deploy
-    needs: build
+    needs: [ build, manifest, scan ]
     if: (needs.build.outputs.deploy_staging == 'true' || (vars.DEPLOY_STAGING_MERGED_PR == 'true' && inputs.version_type == 'pr')) && (inputs.deployment_namespace != '' && inputs.deployment_label_selector != '')
     runs-on: self-hosted-hoprnet-small
     steps:

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -332,12 +332,12 @@ jobs:
             echo "|--------|----------|------------|----------|-----|"
 
             jq -r '
-              .Results[]
+              .Results[]?
               | select(.Vulnerabilities != null)
               | .Target as $target
-              | .Vulnerabilities[]
+              | .Vulnerabilities[]?
               | "| \($target) | \(.PkgName) | \(.InstalledVersion) | \(.Severity) | \(.VulnerabilityID) |"
-            ' trivy.json
+            ' trivy.json || echo "| - | Could not process Trivy results | - | - | - |"
 
           } > trivy-comment.md
       - name: Find existing Trivy comment

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -329,7 +329,7 @@ jobs:
             echo "_Updated for commit \`${{ github.event.pull_request.head.sha }}\`_"
             echo ""
             echo '```'
-            grep -v "     0      " trivy.txt | head -n 500
+            sed '/.*│[[:space:]]*0[[:space:]]*│.*/d' trivy.txt | head -n 500
             echo '```'
             echo ""
           } > trivy-comment.md

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,0 +1,414 @@
+#################################################################################
+# Pipeline to build docker
+#################################################################################
+name: Build docker
+env:
+  RUST_BACKTRACE: "1"
+  CARGO_TERM_COLOR: always
+permissions:
+  contents: read
+on:
+  workflow_call:
+    inputs:
+      source_branch:
+        required: true
+        type: string
+        description: "Source branch to build the binary image from"
+      version_type:
+        required: true
+        type: string
+        description: "Type of version to build: commit, pr, release, rc"
+      build_matrix:
+        description: 'JSON string for the matrix strategy. Must include keys: runner, architecture, build_command, build_debug_command (optional), smoke_test_command (optional)'
+        required: true
+        type: string
+      # architecture:
+      #   required: false
+      #   type: string
+      #   default: "x86_64-linux"
+      #   description: "Target architecture for the docker image"
+      cachix_cache_name:
+        required: true
+        type: string
+        description: "Cachix cache name to use"
+      build_file:
+        required: false
+        type: string
+        default: "Cargo.toml"
+        description: "File to extract version from"
+      # build_command:
+      #   required: true
+      #   type: string
+      #   description: "Command to build the docker image"
+      # build_debug_command:
+      #   required: false
+      #   type: string
+      #   description: "Additional build debug flavor to use"
+      # smoke_test_command:
+      #   required: false
+      #   type: string
+      #   description: "Command to run smoke tests against the built image"
+      docker_image_name:
+        required: true
+        type: string
+        description: "Docker image name"
+      docker_gcp_registry:
+        required: false
+        type: string
+        default: "europe-west3-docker.pkg.dev/hoprassociation/docker-images"
+        description: "Docker registry to push the image to"
+      docker_hub_registry:
+        required: false
+        type: string
+        default: "docker.io/hoprnet"
+        description: "Docker registry to push the image to"
+      timeout_minutes:
+        required: false
+        type: number
+        default: 60
+        description: "Timeout for the job in minutes"
+      # runner:
+      #   required: false
+      #   type: string
+      #   description: "Runner to use for the job"
+      #   default: "self-hosted-hoprnet-bigger"
+      deployment_namespace:
+        required: false
+        type: string
+        description: "Kubernetes namespace for the deployment to restart in staging"
+      deployment_label_selector:
+        required: false
+        type: string
+        description: "Kubernetes label selector for the deployment to restart in staging"
+      fail_on_scan_vulnerabilities:
+        required: false
+        type: string
+        description: "Whether to fail the build if vulnerabilities are found during the scan"
+        default: "true"
+    secrets:
+      gcp_service_account:
+        required: true
+      cachix_auth_token:
+        required: true
+      docker_hub_username:
+        required: false
+      docker_hub_token:
+        required: false
+    outputs:
+      docker_build_version:
+        description: "Docker image version built"
+        value: ${{ jobs.build.outputs.docker_build_version }}
+      docker_debug_version:
+        description: "Docker debug image version built"
+        value: ${{ jobs.build.outputs.docker_debug_version }}
+concurrency:
+  group: build-docker-${{ github.repository }}-${{ inputs.source_branch }}-${{ fromJSON(inputs.build_matrix).architecture }}
+  cancel-in-progress: true
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ fromJSON(inputs.build_matrix).runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    outputs:
+      docker_build_version_platform: ${{ steps.version.outputs.docker_build_version_platform }}
+      docker_build_version: ${{ steps.version.outputs.docker_build_version }}
+      docker_debug_version: ${{ steps.version.outputs.docker_debug_version }}
+      deploy_staging: ${{ steps.version.outputs.deploy_staging }}
+      publish_docker_hub: ${{ steps.docker_hub.outputs.publish_docker_hub }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          disable-sudo: true
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.source_branch }}
+      - name: Updates build version
+        id: version
+        uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v1
+        with:
+          file: "${{ inputs.build_file }}"
+          version_type: "${{ inputs.version_type }}"
+          architecture: "${{ fromJSON(inputs.build_matrix).architecture }}"
+      - name: Setup GCP
+        id: gcp
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        with:
+          google_credentials: ${{ secrets.gcp_service_account }}
+          login_artifact_registry: 'true'
+      - name: Setup Nix
+        uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
+        with:
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
+          cachix_auth_token: "${{ secrets.cachix_auth_token }}"
+      - name: Build docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
+        run: ${{ fromJSON(inputs.build_matrix).build_command }}
+        env:
+          IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
+      # - name: Build staging docker image - ${{ inputs.docker_image_name }}:staging
+      #   if: steps.version.outputs.deploy_staging == 'true' && fromJSON(inputs.build_matrix).architecture == 'x86_64-linux'
+      #   run: ${{ fromJSON(inputs.build_matrix).build_command }}
+      #   env:
+      #     IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:staging
+      - name: Build debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
+        if: steps.version.outputs.docker_debug_version_platform != '' && fromJSON(inputs.build_matrix).build_debug_command != ''
+        run: ${{ fromJSON(inputs.build_matrix).build_debug_command }}
+        env:
+          IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
+      # - name: Build latest docker image - ${{ inputs.docker_image_name }}:latest-${{ steps.version.outputs.docker_platform }}
+      #   if: inputs.version_type == 'pr'
+      #   run: ${{ fromJSON(inputs.build_matrix).build_command }}
+      #   env:
+      #     IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:latest-${{ steps.version.outputs.docker_platform }}
+      - name: Determine DockerHub publishing condition
+        id: docker_hub
+        run: |
+          if [ "${{ inputs.version_type }}" = "release" ] && [ -n "${{ secrets.docker_hub_username }}" ] && [ -n "${{ secrets.docker_hub_token }}" ]; then
+            echo "publish_docker_hub=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "publish_docker_hub=false" | tee -a "$GITHUB_OUTPUT"
+          fi
+      - name: Log in to DockerHub
+        if: steps.docker_hub.outputs.publish_docker_hub == 'true'
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.docker_hub_username }}
+          password: ${{ secrets.docker_hub_token }}
+      # - name: Build docker image - DockerHub - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
+      #   if: steps.docker_hub.outputs.publish_docker_hub == 'true'
+      #   run: ${{ fromJSON(inputs.build_matrix).build_command }}
+      #   env:
+      #     IMAGE_NAME: ${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
+      - name: Publish docker images
+        run: |
+          gcp_image_name="${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}"
+          gcp_image="${gcp_image_name}:${{ steps.version.outputs.docker_build_version_platform }}"
+          echo "Publishing image to GCP Artifact Registry: ${gcp_image}"
+          docker push "${gcp_image}"
+          echo "Published image to GCP Artifact Registry: ${gcp_image}"
+          if [ "${{ steps.version.outputs.deploy_staging }}" = "true" ] && [ "${{ fromJSON(inputs.build_matrix).architecture }}" = "x86_64-linux" ]; then
+            staging_image="${gcp_image_name}:staging"
+            echo "Publishing staging image to GCP Artifact Registry: ${staging_image}"
+            docker tag "${gcp_image}" "${staging_image}"
+            docker push "${staging_image}"
+            echo "Published staging image to GCP Artifact Registry: ${staging_image}"
+          fi
+          if [ "${{ steps.version.outputs.docker_debug_version_platform }}" != "" ] && [ "${{ fromJSON(inputs.build_matrix).build_debug_command }}" != "" ]; then
+            debug_image="${gcp_image_name}:${{ steps.version.outputs.docker_debug_version_platform }}"
+            echo "Publishing debug image to GCP Artifact Registry: ${debug_image}"
+            docker push "${debug_image}"
+            echo "Published debug image to GCP Artifact Registry: ${debug_image}"
+          fi
+          if [ "${{ inputs.version_type }}" = "pr" ] && [ "${{ fromJSON(inputs.build_matrix).architecture }}" = "x86_64-linux" ]; then
+            latest_image="${gcp_image_name}:latest-${{ steps.version.outputs.docker_platform }}"
+            echo "Publishing latest image to GCP Artifact Registry: ${latest_image}"
+            docker tag "${gcp_image}" "${latest_image}"
+            docker push "${latest_image}"
+            echo "Published latest image to GCP Artifact Registry: ${latest_image}"
+          fi
+          if [ "${{ steps.docker_hub.outputs.publish_docker_hub }}" = "true" ]; then
+            docker_hub_image="${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}"
+            echo "Publishing image to DockerHub: ${docker_hub_image}"
+            docker tag "${gcp_image}" "${docker_hub_image}"
+            docker push "${docker_hub_image}"
+            echo "Published image to DockerHub: ${docker_hub_image}"
+          fi
+  manifest:
+    name: Multi-Arch
+    runs-on: self-hosted-hoprnet-small
+    needs: build
+    steps:
+      - name: Setup GCP
+        id: gcp
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        with:
+          google_credentials: ${{ secrets.gcp_service_account }}
+          login_artifact_registry: 'true'
+          install_sdk: 'false'
+      - name: Create multi-arch docker manifest - ${{ needs.build.outputs.docker_build_version }}
+        uses: hoprnet/hopr-workflows/actions/multi-arch-manifest@multi-arch-manifest-v1
+        with:
+          registry: ${{ inputs.docker_gcp_registry }}
+          image: ${{ inputs.docker_image_name }}
+          version: ${{ needs.build.outputs.docker_build_version }}
+      - name: Create debug multi-arch docker manifest - ${{ needs.build.outputs.docker_debug_version }}
+        if: needs.build.outputs.docker_debug_version != ''
+        uses: hoprnet/hopr-workflows/actions/multi-arch-manifest@multi-arch-manifest-v1
+        with:
+          registry: ${{ inputs.docker_gcp_registry }}
+          image: ${{ inputs.docker_image_name }}
+          version: ${{ needs.build.outputs.docker_debug_version }}
+      - name: Create multi-arch docker manifest - latest
+        if: inputs.version_type == 'pr'
+        uses: hoprnet/hopr-workflows/actions/multi-arch-manifest@multi-arch-manifest-v1
+        with:
+          registry: ${{ inputs.docker_gcp_registry }}
+          image: ${{ inputs.docker_image_name }}
+          version: latest
+      - name: Identify Docker hub publish condition
+        id: docker_hub
+        run: |
+          if [ "${{ inputs.version_type }}" = "release" ] && [ -n "${{ secrets.docker_hub_username }}" ] && [ -n "${{ secrets.docker_hub_token }}" ]; then
+            echo "publish=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" | tee -a "$GITHUB_OUTPUT"
+          fi
+      - name: Log in to Docker Hub
+        if: steps.docker_hub.outputs.publish == 'true'
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.docker_hub_username }}
+          password: ${{ secrets.docker_hub_token }}
+      - name: Create multi-arch docker manifest - Docker Hub - ${{ needs.build.outputs.docker_build_version }}
+        if: steps.docker_hub.outputs.publish == 'true'
+        uses: hoprnet/hopr-workflows/actions/multi-arch-manifest@multi-arch-manifest-v1
+        with:
+          registry: ${{ inputs.docker_hub_registry }}
+          image: ${{ inputs.docker_image_name }}
+          version: ${{ needs.build.outputs.docker_build_version }}
+  scan:
+    name: Scan
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Allows to request an identity token. Fetches an OIDC token from GitHub OAuth OIDC provider
+      security-events: write
+    steps:
+      - name: Set up Docker
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
+      - name: Install Trivy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget apt-transport-https gnupg lsb-release 
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
+          echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install -y trivy
+      - name: Install Cosign
+        run: |
+          COSIGN_VERSION="v3.0.3"
+          curl -Lo cosign https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64
+          chmod +x cosign
+          sudo mv cosign /usr/local/bin/cosign
+      - name: Setup GCP
+        id: gcp
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        with:
+          google_credentials: ${{ secrets.gcp_service_account }}
+          login_artifact_registry: 'true'
+          install_sdk: 'true'
+      - name: Get docker image digest
+        id: docker
+        run: |
+          gcp_docker_image="${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ needs.build.outputs.docker_build_version_platform }}"
+          docker pull "${gcp_docker_image}" # Pull the image to inspect
+          echo "gcp_docker_image=${gcp_docker_image}" | tee -a $GITHUB_OUTPUT
+          gcp_docker_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${gcp_docker_image}" | awk -F'@' '{print $2}')
+          echo "gcp_docker_digest=${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}@${gcp_docker_digest}" | tee -a $GITHUB_OUTPUT
+          if [[ "${{ needs.build.outputs.publish_docker_hub }}" == "true" ]]; then
+            docker_hub_image="${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ needs.build.outputs.docker_build_version_platform }}"
+            docker pull "${docker_hub_image}" # Pull the image to inspect
+            echo "docker_hub_image=${docker_hub_image}" | tee -a $GITHUB_OUTPUT
+            docker_hub_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${docker_hub_image}" | awk -F'@' '{print $2}')
+            echo "docker_hub_digest=${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}@${docker_hub_digest}" | tee -a $GITHUB_OUTPUT
+          fi
+      - name: Scan vulnerabilities with Trivy
+        run: |
+          if [ "${{ inputs.fail_on_scan_vulnerabilities }}" = "true" ]; then
+            EXIT_CODE_OPTION="--exit-code 1"
+          else
+            EXIT_CODE_OPTION=""
+          fi
+          trivy image \
+            --format sarif \
+            --output "trivy-results-${{ fromJson(inputs.build_matrix).architecture }}.sarif" \
+            --severity HIGH,CRITICAL \
+            $EXIT_CODE_OPTION \
+            "${{ steps.docker.outputs.gcp_docker_image }}"
+      - name: Upload Trivy vulnerabilities to GitHub Security
+        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        with:
+          sarif_file: trivy-results-${{ fromJson(inputs.build_matrix).architecture }}.sarif
+          category: trivy-${{ fromJson(inputs.build_matrix).architecture }}
+      - name: Generate SBOM
+        run: trivy image --format cyclonedx --output "sbom.json" "${{ steps.docker.outputs.gcp_docker_image }}"
+      - name: Attach SBOM to Google Artifact for attestation
+        run: cosign attest --predicate "sbom.json" --type cyclonedx "${{ steps.docker.outputs.gcp_docker_digest }}"
+        env:
+          COSIGN_YES: "true"
+      - name: Attach SBOM to Google Artifact for vulnerability analysis
+        run: |
+          gcloud artifacts sbom load --project hoprassociation \
+            --source sbom.json \
+            --uri "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ needs.build.outputs.docker_build_version_platform }}" \
+            --destination gs://docker-images-sboms
+      - name: Log in to DockerHub
+        if: needs.build.outputs.publish_docker_hub == 'true'
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.docker_hub_username }}
+          password: ${{ secrets.docker_hub_token }}
+      - name: Attach SBOM to DockerHub for attestation
+        if: needs.build.outputs.publish_docker_hub == 'true'
+        run: cosign attest --predicate "sbom.json" --type cyclonedx "${{ steps.docker.outputs.docker_hub_digest }}"
+        env:
+          COSIGN_YES: "true"
+  smoke-test:
+    name: Smoke Test
+    if: vars.RUN_DOCKER_SMOKE_TESTS == 'true' && fromJson(inputs.build_matrix).architecture == 'x86_64-linux' && fromJson(inputs.build_matrix).smoke_test_command != ''
+    needs: build
+    runs-on: self-hosted-hoprnet-big
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.source_branch }}
+      - name: Setup Nix
+        uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
+        with:
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
+          cachix_auth_token: "${{ secrets.cachix_auth_token }}"
+      - name: Run smoke tests
+        run: ${{ fromJson(inputs.build_matrix).smoke_test_command }} 2>&1 | tee test.logs
+        env:
+          SOURCE_IMAGE: "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ needs.build.outputs.docker_build_version_platform }}"
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: smoke-test-logs
+          path: test.logs
+          retention-days: 7
+  deploy:
+    name: Deploy
+    needs: build
+    if: (needs.build.outputs.deploy_staging == 'true' || (vars.DEPLOY_STAGING_MERGED_PR == 'true' && inputs.version_type == 'pr')) && (inputs.deployment_namespace != '' && inputs.deployment_label_selector != '')
+    runs-on: self-hosted-hoprnet-small
+    steps:
+      - name: Setup GCP
+        id: gcp
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        with:
+          google_credentials: ${{ secrets.gcp_service_account }}
+          install_sdk: 'true'
+          login_gke: 'true'
+          project: hopr-staging
+
+      - name: Deploy in staging
+        run: |
+          echo "Starting deployment restart"
+          if ! kubectl rollout restart deployments -n ${{ inputs.deployment_namespace }} -l ${{ inputs.deployment_label_selector }}; then
+            echo "Failed to restart deployment"
+            exit 1
+          fi
+          if ! kubectl rollout status deployments -n ${{ inputs.deployment_namespace }} -l ${{ inputs.deployment_label_selector }} --timeout=600s; then
+            echo "Deployment did not complete within the timeout period"
+            exit 1
+          fi
+          echo "Restart completed successfully"
+        timeout-minutes: 15

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -108,6 +108,7 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.source_branch }}
+          token: ${{ github.token }} # Required for private repositories to fetch the code on NixOs runners
       - name: Updates build version
         id: version
         uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v2

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -322,13 +322,14 @@ jobs:
           output: trivy.txt
       - name: Build PR comment body
         run: |
+          # Build a markdown comment body with the Trivy report, excluding lines with "0" vulnerabilities and limiting to 500 lines to avoid hitting comment size limits
           {
             echo "## 🔎 Trivy report"
             echo ""
             echo "_Updated for commit \`${{ github.event.pull_request.head.sha }}\`_"
             echo ""
             echo '```'
-            grep -v "     0      " trivy.txt | head -n 650
+            grep -v "     0      " trivy.txt | head -n 500
             echo '```'
             echo ""
           } > trivy-comment.md

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -152,52 +152,48 @@ jobs:
           password: ${{ secrets.docker_hub_token }}
       - name: Build docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
         run: ${{ matrix.build_command }}
-        env:
-          IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
       - name: Publish docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
         run: |
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
             set -euo pipefail
-            gcp_image_name="${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}"
-            gcp_image="${gcp_image_name}:${{ steps.version.outputs.docker_build_version_platform }}"
-            echo "Publishing image to GCP Artifact Registry: ${gcp_image}"
-            skopeo copy docker-archive:./result "docker://${gcp_image}"
-            echo "Published image to GCP Artifact Registry: ${gcp_image}"
+            echo "Publishing image to GCP Artifact Registry: ${GCP_IMAGE_NAME}"
+            skopeo copy docker-archive:./result "docker://${GCP_IMAGE_NAME}"
+            echo "Published image to GCP Artifact Registry: ${GCP_IMAGE_NAME}"
             if [[ "${{ steps.version.outputs.deploy_staging }}" == "true" && "${{ matrix.architecture }}" == "x86_64-linux" ]]; then
-              staging_image="${gcp_image_name}:staging"
-              echo "Publishing staging image to GCP Artifact Registry: ${staging_image}"
-              skopeo copy docker-archive:./result "docker://${staging_image}"
-              echo "Published staging image to GCP Artifact Registry: ${staging_image}"
+              echo "Publishing staging image to GCP Artifact Registry: ${GCP_STAGING_IMAGE_NAME}"
+              skopeo copy docker-archive:./result "docker://${GCP_STAGING_IMAGE_NAME}"
+              echo "Published staging image to GCP Artifact Registry: ${GCP_STAGING_IMAGE_NAME}"
             fi
             if [[ "${{ inputs.version_type }}" == "pr" ]]; then
-              latest_image="${gcp_image_name}:latest-${{ steps.version.outputs.docker_platform }}"
-              echo "Publishing latest image to GCP Artifact Registry: ${latest_image}"
-              skopeo copy docker-archive:./result "docker://${latest_image}"
-              echo "Published latest image to GCP Artifact Registry: ${latest_image}"
+              echo "Publishing latest image to GCP Artifact Registry: ${GCP_LATEST_IMAGE_NAME}"
+              skopeo copy docker-archive:./result "docker://${GCP_LATEST_IMAGE_NAME}"
+              echo "Published latest image to GCP Artifact Registry: ${GCP_LATEST_IMAGE_NAME}"
             fi
             if [[ "${{ steps.docker_hub.outputs.publish_docker_hub }}" == "true" ]]; then
-              docker_hub_image="${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}"
-              echo "Publishing image to DockerHub: ${docker_hub_image}"
-              skopeo copy docker-archive:./result "docker://${docker_hub_image}"
-              echo "Published image to DockerHub: ${docker_hub_image}"
+              echo "Publishing image to DockerHub: ${DOCKER_HUB_IMAGE_NAME}"
+              skopeo copy docker-archive:./result "docker://${DOCKER_HUB_IMAGE_NAME}"
+              echo "Published image to DockerHub: ${DOCKER_HUB_IMAGE_NAME}"
             fi
           SKOPEO
+        env:
+          GCP_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
+          GCP_STAGING_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:staging
+          GCP_LATEST_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:latest-${{ steps.version.outputs.docker_platform }}
+          DOCKER_HUB_IMAGE_NAME: ${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
       - name: Build debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
         if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
         run: ${{ matrix.build_debug_command }}
-        env:
-          IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
       - name: Publish debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
         if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
         run: |
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
             set -euo pipefail
-            gcp_image_name="${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}"
-            debug_image="${gcp_image_name}:${{ steps.version.outputs.docker_debug_version_platform }}"
-            echo "Publishing debug image to GCP Artifact Registry: ${debug_image}"
-            skopeo copy docker-archive:./result "docker://${debug_image}"
-            echo "Published debug image to GCP Artifact Registry: ${debug_image}"
+            echo "Publishing debug image to GCP Artifact Registry: ${GCP_DEBUG_IMAGE_NAME}"
+            skopeo copy docker-archive:./result "docker://${GCP_DEBUG_IMAGE_NAME}"
+            echo "Published debug image to GCP Artifact Registry: ${GCP_DEBUG_IMAGE_NAME}"
           SKOPEO
+        env:
+          GCP_DEBUG_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
       - name: Remove git credentials
         if: ${{ github.event.repository.private && always() }}
         run: |

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -18,7 +18,7 @@ on:
       version_type:
         required: true
         type: string
-        description: "Type of version to build: commit, pr, release, rc"
+        description: "Type of version to build: commit, pr, release"
       build_matrix:
         description: 'JSON string for the matrix strategy. Must include keys: runner, architecture, build_command, build_debug_command (optional), smoke_test_command (optional)'
         required: true
@@ -127,7 +127,7 @@ jobs:
           architecture: "${{ matrix.architecture }}"
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ secrets.gcp_service_account }}
           login_artifact_registry: 'true'
@@ -205,7 +205,7 @@ jobs:
     steps:
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ secrets.gcp_service_account }}
           login_artifact_registry: 'true'
@@ -271,7 +271,7 @@ jobs:
           cosign-release: 'v3.0.5'
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ secrets.gcp_service_account }}
           login_artifact_registry: 'true'
@@ -311,6 +311,7 @@ jobs:
             echo "trivy_exit_code=0" | tee -a $GITHUB_OUTPUT
           fi
       - name: Run Trivy
+        if: inputs.version_type == 'commit'
         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # v0.34.1
         with:
           image-ref: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.platform.outputs.docker_build_version_platform }}
@@ -321,6 +322,7 @@ jobs:
           severity: "HIGH,CRITICAL"
           output: trivy.json
       - name: Build Security Report Markdown
+        if: inputs.version_type == 'commit'
         run: |
           {
             echo "## 🔎 Trivy Security Report"
@@ -338,6 +340,7 @@ jobs:
 
           } > trivy-comment.md
       - name: Find existing Trivy comment
+        if: inputs.version_type == 'commit'
         id: find
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad #v4.0.0
         with:
@@ -346,6 +349,7 @@ jobs:
           body-includes: "## 🔎 Trivy Security Report"
 
       - name: Create or update Trivy comment
+        if: inputs.version_type == 'commit'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 #v5.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -433,7 +437,7 @@ jobs:
     steps:
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ secrets.gcp_service_account }}
           install_sdk: 'true'

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -333,7 +333,7 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJSON(inputs.build_matrix) }}
-    if: vars.RUN_DOCKER_SMOKE_TESTS == 'true' && matrix.smoke_test_command != ''
+    if: vars.RUN_DOCKER_SMOKE_TESTS == 'true'
     needs: build
     steps:
       - name: Checkout repository
@@ -352,7 +352,7 @@ jobs:
         env:
           SOURCE_IMAGE: "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ needs.build.outputs.docker_build_version_platform }}"
       - name: Upload logs on failure
-        if: failure()
+        if: failure() && matrix.smoke_test_command != ''
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: smoke-test-logs

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -110,7 +110,7 @@ jobs:
           ref: ${{ inputs.source_branch }}
       - name: Updates build version
         id: version
-        uses: hoprnet/hopr-workflows/actions/set-build-version@ausias/workflows-v2
+        uses: hoprnet/hopr-workflows/actions/set-build-version@ausias/workflows-v2 # @set-build-version-v2
         with:
           file: "${{ inputs.build_file }}"
           version_type: "${{ inputs.version_type }}"
@@ -251,13 +251,17 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
       - name: Install Trivy
+        env:
+          TRIVY_VERSION: "0.61.0"
         run: |
+          sudo mkdir -p /etc/apt/keyrings
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key \
+            | gpg --dearmor \
+            | sudo tee /etc/apt/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/etc/apt/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" \
+            | sudo tee /etc/apt/sources.list.d/trivy.list
           sudo apt-get update
-          sudo apt-get install -y wget apt-transport-https gnupg lsb-release 
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-          echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install -y trivy
+          sudo apt-get install -y trivy=${TRIVY_VERSION}
       - name: Install Cosign
         run: |
           COSIGN_VERSION="v3.0.3"
@@ -326,7 +330,7 @@ jobs:
           COSIGN_YES: "true"
       - name: Attach SBOM to Google Artifact for vulnerability analysis
         run: |
-          gcloud artifacts sbom load --project hoprassociation \
+          gcloud artifacts sbom load \
             --source sbom.json \
             --uri "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.platform.outputs.docker_build_version_platform }}" \
             --destination gs://docker-images-sboms
@@ -364,12 +368,12 @@ jobs:
         if: matrix.smoke_test_command != ''
         run: ${{ matrix.smoke_test_command }} 2>&1 | tee test.logs
         env:
-          SOURCE_IMAGE: "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ needs.build.outputs.docker_build_version_platform }}"
+          SOURCE_IMAGE: "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ needs.build.outputs.docker_build_version }}"
       - name: Upload logs on failure
         if: failure() && matrix.smoke_test_command != ''
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: smoke-test-logs
+          name: smoke-test-logs-${{ matrix.architecture }}
           path: test.logs
           retention-days: 7
   deploy:
@@ -390,11 +394,11 @@ jobs:
       - name: Deploy in staging
         run: |
           echo "Starting deployment restart"
-          if ! kubectl rollout restart deployments -n ${{ inputs.deployment_namespace }} -l ${{ inputs.deployment_label_selector }}; then
+          if ! kubectl rollout restart deployments -n "${{ inputs.deployment_namespace }}" -l "${{ inputs.deployment_label_selector }}"; then
             echo "Failed to restart deployment"
             exit 1
           fi
-          if ! kubectl rollout status deployments -n ${{ inputs.deployment_namespace }} -l ${{ inputs.deployment_label_selector }} --timeout=600s; then
+          if ! kubectl rollout status deployments -n "${{ inputs.deployment_namespace }}" -l "${{ inputs.deployment_label_selector }}" --timeout=600s; then
             echo "Deployment did not complete within the timeout period"
             exit 1
           fi

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -84,7 +84,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
-    name: Build
+    name: Build (${{ matrix.architecture }})
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -237,7 +237,7 @@ jobs:
           image: ${{ inputs.docker_image_name }}
           version: ${{ needs.build.outputs.docker_build_version }}
   scan:
-    name: Scan
+    name: Scan (${{ matrix.architecture }})
     needs: build
     runs-on: ubuntu-latest
     strategy:
@@ -328,7 +328,7 @@ jobs:
         env:
           COSIGN_YES: "true"
   smoke-test:
-    name: Smoke Test
+    name: Smoke Test (${{ matrix.architecture }})
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -328,7 +328,7 @@ jobs:
             echo "_Updated for commit \`${{ github.event.pull_request.head.sha }}\`_"
             echo ""
             echo '```'
-            sed -n '1,650p' trivy.txt
+            grep -v "     0      " trivy.txt | head -n 650
             echo '```'
             echo ""
           } > trivy-comment.md

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -271,16 +271,30 @@ jobs:
           google_credentials: ${{ secrets.gcp_service_account }}
           login_artifact_registry: 'true'
           install_sdk: 'true'
+      - name: Compute platform-specific tags
+        id: platform
+        run: |
+          base_version="${{ needs.build.outputs.docker_build_version }}"
+          if [[ "${{ matrix.architecture }}" == "aarch64-linux" ]]; then
+            echo "docker_build_version_platform=${base_version}-linux-arm64" | tee -a $GITHUB_OUTPUT
+            echo "docker_platform=linux-arm64" | tee -a $GITHUB_OUTPUT
+          elif [[ "${{ matrix.architecture }}" == "x86_64-linux" ]]; then
+            echo "docker_build_version_platform=${base_version}-linux-amd64" | tee -a $GITHUB_OUTPUT
+            echo "docker_platform=linux-amd64" | tee -a $GITHUB_OUTPUT
+          else
+            echo "Unsupported architecture: ${{ matrix.architecture }}"
+            exit 1
+          fi
       - name: Get docker image digest
         id: docker
         run: |
-          gcp_docker_image="${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ needs.build.outputs.docker_build_version_platform }}"
+          gcp_docker_image="${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.platform.outputs.docker_build_version_platform }}"
           docker pull "${gcp_docker_image}" # Pull the image to inspect
           echo "gcp_docker_image=${gcp_docker_image}" | tee -a $GITHUB_OUTPUT
           gcp_docker_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${gcp_docker_image}" | awk -F'@' '{print $2}')
           echo "gcp_docker_digest=${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}@${gcp_docker_digest}" | tee -a $GITHUB_OUTPUT
           if [[ "${{ needs.build.outputs.publish_docker_hub }}" == "true" ]]; then
-            docker_hub_image="${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ needs.build.outputs.docker_build_version_platform }}"
+            docker_hub_image="${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.platform.outputs.docker_build_version_platform }}"
             docker pull "${docker_hub_image}" # Pull the image to inspect
             echo "docker_hub_image=${docker_hub_image}" | tee -a $GITHUB_OUTPUT
             docker_hub_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${docker_hub_image}" | awk -F'@' '{print $2}')
@@ -295,15 +309,15 @@ jobs:
           fi
           trivy image \
             --format sarif \
-            --output "trivy-results-${{ needs.build.outputs.docker_platform }}.sarif" \
+            --output "trivy-results-${{ steps.platform.outputs.docker_platform }}.sarif" \
             --severity HIGH,CRITICAL \
             $EXIT_CODE_OPTION \
             "${{ steps.docker.outputs.gcp_docker_image }}"
       - name: Upload Trivy vulnerabilities to GitHub Security
         uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
         with:
-          sarif_file: trivy-results-${{ needs.build.outputs.docker_platform }}.sarif
-          category: trivy-${{ needs.build.outputs.docker_platform }}
+          sarif_file: trivy-results-${{ steps.platform.outputs.docker_platform }}.sarif
+          category: trivy-${{ steps.platform.outputs.docker_platform }}
       - name: Generate SBOM
         run: trivy image --format cyclonedx --output "sbom.json" "${{ steps.docker.outputs.gcp_docker_image }}"
       - name: Attach SBOM to Google Artifact for attestation
@@ -314,7 +328,7 @@ jobs:
         run: |
           gcloud artifacts sbom load --project hoprassociation \
             --source sbom.json \
-            --uri "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ needs.build.outputs.docker_build_version_platform }}" \
+            --uri "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.platform.outputs.docker_build_version_platform }}" \
             --destination gs://docker-images-sboms
       - name: Log in to DockerHub
         if: needs.build.outputs.publish_docker_hub == 'true'

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -110,7 +110,7 @@ jobs:
           ref: ${{ inputs.source_branch }}
       - name: Updates build version
         id: version
-        uses: hoprnet/hopr-workflows/actions/set-build-version@ausias/workflows-v2 # @set-build-version-v2
+        uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v2
         with:
           file: "${{ inputs.build_file }}"
           version_type: "${{ inputs.version_type }}"

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -157,21 +157,21 @@ jobs:
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
             set -euo pipefail
             echo "Publishing image to GCP Artifact Registry: ${GCP_IMAGE_NAME}"
-            skopeo copy docker-archive:./result "docker://${GCP_IMAGE_NAME}"
+            skopeo --insecure-policy copy docker-archive:./result "docker://${GCP_IMAGE_NAME}"
             echo "Published image to GCP Artifact Registry: ${GCP_IMAGE_NAME}"
             if [[ "${{ steps.version.outputs.deploy_staging }}" == "true" && "${{ matrix.architecture }}" == "x86_64-linux" ]]; then
               echo "Publishing staging image to GCP Artifact Registry: ${GCP_STAGING_IMAGE_NAME}"
-              skopeo copy docker-archive:./result "docker://${GCP_STAGING_IMAGE_NAME}"
+              skopeo --insecure-policy copy docker-archive:./result "docker://${GCP_STAGING_IMAGE_NAME}"
               echo "Published staging image to GCP Artifact Registry: ${GCP_STAGING_IMAGE_NAME}"
             fi
             if [[ "${{ inputs.version_type }}" == "pr" ]]; then
               echo "Publishing latest image to GCP Artifact Registry: ${GCP_LATEST_IMAGE_NAME}"
-              skopeo copy docker-archive:./result "docker://${GCP_LATEST_IMAGE_NAME}"
+              skopeo --insecure-policy copy docker-archive:./result "docker://${GCP_LATEST_IMAGE_NAME}"
               echo "Published latest image to GCP Artifact Registry: ${GCP_LATEST_IMAGE_NAME}"
             fi
             if [[ "${{ steps.docker_hub.outputs.publish_docker_hub }}" == "true" ]]; then
               echo "Publishing image to DockerHub: ${DOCKER_HUB_IMAGE_NAME}"
-              skopeo copy docker-archive:./result "docker://${DOCKER_HUB_IMAGE_NAME}"
+              skopeo --insecure-policy copy docker-archive:./result "docker://${DOCKER_HUB_IMAGE_NAME}"
               echo "Published image to DockerHub: ${DOCKER_HUB_IMAGE_NAME}"
             fi
           SKOPEO
@@ -189,7 +189,7 @@ jobs:
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
             set -euo pipefail
             echo "Publishing debug image to GCP Artifact Registry: ${GCP_DEBUG_IMAGE_NAME}"
-            skopeo copy docker-archive:./result "docker://${GCP_DEBUG_IMAGE_NAME}"
+            skopeo --insecure-policy copy docker-archive:./result "docker://${GCP_DEBUG_IMAGE_NAME}"
             echo "Published debug image to GCP Artifact Registry: ${GCP_DEBUG_IMAGE_NAME}"
           SKOPEO
         env:

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -110,7 +110,7 @@ jobs:
           ref: ${{ inputs.source_branch }}
       - name: Updates build version
         id: version
-        uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v1
+        uses: hoprnet/hopr-workflows/actions/set-build-version@ausias/workflows-v2
         with:
           file: "${{ inputs.build_file }}"
           version_type: "${{ inputs.version_type }}"

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -263,11 +263,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y trivy=${TRIVY_VERSION}
       - name: Install Cosign
-        run: |
-          COSIGN_VERSION="v3.0.3"
-          curl -Lo cosign https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64
-          chmod +x cosign
-          sudo mv cosign /usr/local/bin/cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: 'v3.0.5'
       - name: Setup GCP
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -136,15 +136,6 @@ jobs:
         with:
           cachix_cache_name: ${{ inputs.cachix_cache_name }}
           cachix_auth_token: "${{ secrets.cachix_auth_token }}"
-      - name: Build docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
-        run: ${{ matrix.build_command }}
-        env:
-          IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
-      - name: Build debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
-        if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
-        run: ${{ matrix.build_debug_command }}
-        env:
-          IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
       - name: Determine DockerHub publishing condition
         id: docker_hub
         run: |
@@ -159,40 +150,54 @@ jobs:
         with:
           username: ${{ secrets.docker_hub_username }}
           password: ${{ secrets.docker_hub_token }}
-      - name: Publish docker images
+      - name: Build docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
+        run: ${{ matrix.build_command }}
+        env:
+          IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
+      - name: Publish docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
         run: |
-          gcp_image_name="${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}"
-          gcp_image="${gcp_image_name}:${{ steps.version.outputs.docker_build_version_platform }}"
-          echo "Publishing image to GCP Artifact Registry: ${gcp_image}"
-          docker push "${gcp_image}"
-          echo "Published image to GCP Artifact Registry: ${gcp_image}"
-          if [[ "${{ steps.version.outputs.deploy_staging }}" == "true" && "${{ matrix.architecture }}" == "x86_64-linux" ]]; then
-            staging_image="${gcp_image_name}:staging"
-            echo "Publishing staging image to GCP Artifact Registry: ${staging_image}"
-            docker tag "${gcp_image}" "${staging_image}"
-            docker push "${staging_image}"
-            echo "Published staging image to GCP Artifact Registry: ${staging_image}"
-          fi
-          if [[ "${{ steps.version.outputs.docker_debug_version_platform }}" != "" && "${{ matrix.build_debug_command }}" != "" ]]; then
+          nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
+            set -euo pipefail
+            gcp_image_name="${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}"
+            gcp_image="${gcp_image_name}:${{ steps.version.outputs.docker_build_version_platform }}"
+            echo "Publishing image to GCP Artifact Registry: ${gcp_image}"
+            skopeo copy docker-archive:./result "docker://${gcp_image}"
+            echo "Published image to GCP Artifact Registry: ${gcp_image}"
+            if [[ "${{ steps.version.outputs.deploy_staging }}" == "true" && "${{ matrix.architecture }}" == "x86_64-linux" ]]; then
+              staging_image="${gcp_image_name}:staging"
+              echo "Publishing staging image to GCP Artifact Registry: ${staging_image}"
+              skopeo copy docker-archive:./result "docker://${staging_image}"
+              echo "Published staging image to GCP Artifact Registry: ${staging_image}"
+            fi
+            if [[ "${{ inputs.version_type }}" == "pr" ]]; then
+              latest_image="${gcp_image_name}:latest-${{ steps.version.outputs.docker_platform }}"
+              echo "Publishing latest image to GCP Artifact Registry: ${latest_image}"
+              skopeo copy docker-archive:./result "docker://${latest_image}"
+              echo "Published latest image to GCP Artifact Registry: ${latest_image}"
+            fi
+            if [[ "${{ steps.docker_hub.outputs.publish_docker_hub }}" == "true" ]]; then
+              docker_hub_image="${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}"
+              echo "Publishing image to DockerHub: ${docker_hub_image}"
+              skopeo copy docker-archive:./result "docker://${docker_hub_image}"
+              echo "Published image to DockerHub: ${docker_hub_image}"
+            fi
+          SKOPEO
+      - name: Build debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
+        if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
+        run: ${{ matrix.build_debug_command }}
+        env:
+          IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
+      - name: Publish debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
+        if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
+        run: |
+          nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
+            set -euo pipefail
+            gcp_image_name="${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}"
             debug_image="${gcp_image_name}:${{ steps.version.outputs.docker_debug_version_platform }}"
             echo "Publishing debug image to GCP Artifact Registry: ${debug_image}"
-            docker push "${debug_image}"
+            skopeo copy docker-archive:./result "docker://${debug_image}"
             echo "Published debug image to GCP Artifact Registry: ${debug_image}"
-          fi
-          if [[ "${{ inputs.version_type }}" == "pr" ]]; then
-            latest_image="${gcp_image_name}:latest-${{ steps.version.outputs.docker_platform }}"
-            echo "Publishing latest image to GCP Artifact Registry: ${latest_image}"
-            docker tag "${gcp_image}" "${latest_image}"
-            docker push "${latest_image}"
-            echo "Published latest image to GCP Artifact Registry: ${latest_image}"
-          fi
-          if [[ "${{ steps.docker_hub.outputs.publish_docker_hub }}" == "true" ]]; then
-            docker_hub_image="${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}"
-            echo "Publishing image to DockerHub: ${docker_hub_image}"
-            docker tag "${gcp_image}" "${docker_hub_image}"
-            docker push "${docker_hub_image}"
-            echo "Published image to DockerHub: ${docker_hub_image}"
-          fi
+          SKOPEO
       - name: Remove git credentials
         if: ${{ github.event.repository.private && always() }}
         run: |

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -252,16 +252,11 @@ jobs:
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
       - name: Install Trivy
         env:
-          TRIVY_VERSION: "0.61.0"
+          TRIVY_VERSION: "0.69.1"
         run: |
-          sudo mkdir -p /etc/apt/keyrings
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key \
-            | gpg --dearmor \
-            | sudo tee /etc/apt/keyrings/trivy.gpg > /dev/null
-          echo "deb [signed-by=/etc/apt/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" \
-            | sudo tee /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install -y trivy=${TRIVY_VERSION}
+          curl -Lo trivy.deb "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb"
+          sudo apt-get install -y ./trivy.deb
+          rm trivy.deb
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -304,32 +304,36 @@ jobs:
             echo "docker_hub_digest=${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}@${docker_hub_digest}" | tee -a $GITHUB_OUTPUT
           fi
           if [ "${{ inputs.fail_on_scan_vulnerabilities }}" = "true" ]; then
-            echo "trivy_exit_code=1" | tee -a $GITHUB_ENV
+            echo "trivy_exit_code=1" | tee -a $GITHUB_OUTPUT
           else
-            echo "trivy_exit_code=0" | tee -a $GITHUB_ENV
+            echo "trivy_exit_code=0" | tee -a $GITHUB_OUTPUT
           fi
       - name: Run Trivy
         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # v0.34.1
         with:
           image-ref: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.platform.outputs.docker_build_version_platform }}
-          format: table
+          format: json
           exit-code: "${{ steps.docker.outputs.trivy_exit_code }}"
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "HIGH,CRITICAL"
-          output: trivy.txt
-      - name: Build PR comment body
+          output: trivy.json
+      - name: Build Markdown table with headers
         run: |
-          # Build a markdown comment body with the Trivy report, excluding lines with "0" vulnerabilities and limiting to 500 lines to avoid hitting comment size limits
           {
-            echo "## 🔎 Trivy report"
+            echo "## 🔎 Trivy Security Report"
             echo ""
-            echo "_Updated for commit \`${{ github.event.pull_request.head.sha }}\`_"
-            echo ""
-            echo '```'
-            sed '/.*│[[:space:]]*0[[:space:]]*│.*/d' trivy.txt | head -n 500
-            echo '```'
-            echo ""
+            echo "| Target | Package | Installed | Severity | CVE |"
+            echo "|--------|----------|------------|----------|-----|"
+
+            jq -r '
+              .Results[]
+              | select(.Vulnerabilities != null)
+              | .Target as $target
+              | .Vulnerabilities[]
+              | "| \($target) | \(.PkgName) | \(.InstalledVersion) | \(.Severity) | \(.VulnerabilityID) |"
+            ' trivy.json
+
           } > trivy-comment.md
       - name: Find existing Trivy comment
         id: find
@@ -337,7 +341,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
-          body-includes: "## 🔎 Trivy report"
+          body-includes: "## 🔎 Trivy Security Report"
 
       - name: Create or update Trivy comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 #v5.0.0

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -259,8 +259,6 @@ jobs:
         include: ${{ fromJSON(inputs.build_matrix) }}
     permissions:
       contents: read
-      id-token: write # Allows to request an identity token. Fetches an OIDC token from GitHub OAuth OIDC provider
-      security-events: write
       pull-requests: write
     steps:
       - name: Set up Docker

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -261,6 +261,7 @@ jobs:
       contents: read
       id-token: write # Allows to request an identity token. Fetches an OIDC token from GitHub OAuth OIDC provider
       security-events: write
+      pull-requests: write
     steps:
       - name: Set up Docker
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -219,18 +219,18 @@ jobs:
         id: docker_hub
         run: |
           if [ "${{ inputs.version_type }}" = "release" ] && [ -n "${{ secrets.docker_hub_username }}" ] && [ -n "${{ secrets.docker_hub_token }}" ]; then
-            echo "publish=true" | tee -a "$GITHUB_OUTPUT"
+            echo "publish_dockerhub=true" | tee -a "$GITHUB_OUTPUT"
           else
-            echo "publish=false" | tee -a "$GITHUB_OUTPUT"
+            echo "publish_dockerhub=false" | tee -a "$GITHUB_OUTPUT"
           fi
       - name: Log in to Docker Hub
-        if: steps.docker_hub.outputs.publish == 'true'
+        if: steps.docker_hub.outputs.publish_dockerhub == 'true'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.docker_hub_username }}
           password: ${{ secrets.docker_hub_token }}
       - name: Create multi-arch docker manifest - Docker Hub - ${{ needs.build.outputs.docker_build_version }}
-        if: steps.docker_hub.outputs.publish == 'true'
+        if: steps.docker_hub.outputs.publish_dockerhub == 'true'
         uses: hoprnet/hopr-workflows/actions/multi-arch-manifest@multi-arch-manifest-v1
         with:
           registry: ${{ inputs.docker_hub_registry }}

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -7,6 +7,7 @@ env:
   CARGO_TERM_COLOR: always
 permissions:
   contents: read
+  id-token: write # Required for cosign keyless attestation and GCP Workload Identity
 on:
   workflow_call:
     inputs:
@@ -260,6 +261,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write # Required for cosign keyless attestation and GCP Workload Identity
     steps:
       - name: Set up Docker
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
@@ -318,7 +320,7 @@ jobs:
           vuln-type: "os,library"
           severity: "HIGH,CRITICAL"
           output: trivy.json
-      - name: Build Markdown table with headers
+      - name: Build Security Report Markdown
         run: |
           {
             echo "## 🔎 Trivy Security Report"

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -80,7 +80,7 @@ on:
         description: "Docker debug image version built"
         value: ${{ jobs.build.outputs.docker_debug_version }}
 concurrency:
-  group: build-docker-${{ github.repository }}-${{ inputs.source_branch }}
+  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}
   cancel-in-progress: true
 jobs:
   build:

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -103,12 +103,20 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+      - name: Configure git credentials for private repositories
+        if: ${{ github.event.repository.private }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TOKEN_B64=$(echo -n "x-access-token:${GH_TOKEN}" | base64 | tr -d '\n')
+          CONFIG_FILE="${RUNNER_TEMP}/gitconfig-credentials"
+          printf '[http "https://github.com/"]\n\textraheader = AUTHORIZATION: basic %s\n' "${TOKEN_B64}" > "${CONFIG_FILE}"
+          echo "GIT_CONFIG_GLOBAL=${CONFIG_FILE}" >> "${GITHUB_ENV}"
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
           ref: ${{ inputs.source_branch }}
-          token: ${{ github.token }} # Required for private repositories to fetch the code on NixOs runners
       - name: Updates build version
         id: version
         uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v2
@@ -184,6 +192,11 @@ jobs:
             docker push "${docker_hub_image}"
             echo "Published image to DockerHub: ${docker_hub_image}"
           fi
+      - name: Remove git credentials
+        if: ${{ github.event.repository.private && always() }}
+        run: |
+          rm -f "${GIT_CONFIG_GLOBAL}" || true
+          echo "GIT_CONFIG_GLOBAL=" >> "${GITHUB_ENV}"
   manifest:
     name: Multi-Arch
     runs-on: self-hosted-hoprnet-small
@@ -348,6 +361,15 @@ jobs:
     if: vars.RUN_DOCKER_SMOKE_TESTS == 'true'
     needs: build
     steps:
+      - name: Configure git credentials for private repositories
+        if: ${{ github.event.repository.private }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TOKEN_B64=$(echo -n "x-access-token:${GH_TOKEN}" | base64 | tr -d '\n')
+          CONFIG_FILE="${RUNNER_TEMP}/gitconfig-credentials"
+          printf '[http "https://github.com/"]\n\textraheader = AUTHORIZATION: basic %s\n' "${TOKEN_B64}" > "${CONFIG_FILE}"
+          echo "GIT_CONFIG_GLOBAL=${CONFIG_FILE}" >> "${GITHUB_ENV}"
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -370,6 +392,11 @@ jobs:
           name: smoke-test-logs-${{ matrix.architecture }}
           path: test.logs
           retention-days: 7
+      - name: Remove git credentials
+        if: ${{ github.event.repository.private && always() }}
+        run: |
+          rm -f "${GIT_CONFIG_GLOBAL}" || true
+          echo "GIT_CONFIG_GLOBAL=" >> "${GITHUB_ENV}"
   deploy:
     name: Deploy
     needs: [ build, manifest, scan ]

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -81,7 +81,7 @@ on:
         description: "Docker debug image version built"
         value: ${{ jobs.build.outputs.docker_debug_version }}
 concurrency:
-  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}
+  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-docker
   cancel-in-progress: true
 jobs:
   build:

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -161,6 +161,7 @@ jobs:
         run: |
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
             set -euo pipefail
+            base_branch=${{ github.event.pull_request.base.ref }}
             publish_image() {
               local target_image="${1}"
               echo "Publishing image ${target_image}"
@@ -172,23 +173,44 @@ jobs:
               fi
               echo "Published image ${target_image}"
             }
+            # Default image tag for all version types
             publish_image "${GCP_IMAGE_NAME}"
+
+            # Staging publish condition: only publish staging image for x86_64 architecture
             if [[ "${{ steps.version.outputs.deploy_staging }}" == "true" && "${{ matrix.architecture }}" == "x86_64-linux" ]]; then
               publish_image "${GCP_STAGING_IMAGE_NAME}"
             fi
+
+            # Close PR tags
             if [[ "${{ inputs.version_type }}" == "pr" ]]; then
               publish_image "${GCP_LATEST_IMAGE_NAME}"
+              if [[ "${base_branch}" == "main" ]] || [[ "${base_branch}" == "master" ]]; then
+                publish_image "${GCP_LATEST_MAIN_IMAGE_NAME}"
+              elif [[ "${base_branch}" =~ ^release/* ]]; then
+                publish_image "${GCP_LATEST_LTS_IMAGE_NAME}"
+              fi
             fi
-            if [[ "${{ steps.docker_hub.outputs.publish_docker_hub }}" == "true" ]]; then
-              publish_image "${GCP_LATEST_RELEASE_IMAGE_NAME}"
-              publish_image "${DOCKER_HUB_IMAGE_NAME}"
+
+            # Release tags
+            if [[ "${{ inputs.version_type }}" == "release" ]]; then
+              if [[ "${base_branch}" == "main" ]] || [[ "${base_branch}" == "master" ]]; then
+                publish_image "${GCP_RELEASE_MAIN_IMAGE_NAME}"
+              elif [[ "${base_branch}" =~ ^release/* ]]; then
+                publish_image "${GCP_RELEASE_LTS_IMAGE_NAME}"
+              fi
+              if [[ "${{ steps.docker_hub.outputs.publish_docker_hub }}" == "true" ]]; then
+                publish_image "${DOCKER_HUB_IMAGE_NAME}"
+              fi
             fi
           SKOPEO
         env:
           GCP_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
           GCP_STAGING_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:staging
           GCP_LATEST_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:latest-${{ steps.version.outputs.docker_platform }}
-          GCP_LATEST_RELEASE_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:latest-release-${{ steps.version.outputs.docker_platform }}
+          GCP_LATEST_MAIN_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:latest-main-${{ steps.version.outputs.docker_platform }}
+          GCP_LATEST_LTS_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:latest-lts-${{ steps.version.outputs.docker_platform }}
+          GCP_RELEASE_MAIN_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:release-main-${{ steps.version.outputs.docker_platform }}
+          GCP_RELEASE_LTS_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:release-lts-${{ steps.version.outputs.docker_platform }}
           DOCKER_HUB_IMAGE_NAME: ${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
       - name: Build debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
         if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
@@ -246,29 +268,50 @@ jobs:
           registry: ${{ inputs.docker_gcp_registry }}
           image: ${{ inputs.docker_image_name }}
           version: latest
-      - name: Identify Docker hub publish condition
-        id: docker_hub
-        run: |
-          if [ "${{ inputs.version_type }}" = "release" ] && [ -n "${{ secrets.docker_hub_username }}" ] && [ -n "${{ secrets.docker_hub_token }}" ]; then
-            echo "publish_dockerhub=true" | tee -a "$GITHUB_OUTPUT"
-          else
-            echo "publish_dockerhub=false" | tee -a "$GITHUB_OUTPUT"
-          fi
-      - name: Create multi-arch docker manifest - latest-release
-        if: inputs.version_type == 'release'
+      - name: Create multi-arch docker manifest - latest-main
+        if: inputs.version_type == 'pr' && (github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'master')
         uses: hoprnet/hopr-workflows/actions/multi-arch-manifest@multi-arch-manifest-v1
         with:
           registry: ${{ inputs.docker_gcp_registry }}
           image: ${{ inputs.docker_image_name }}
-          version: latest-release
+          version: latest-main
+      - name: Create multi-arch docker manifest - latest-lts
+        if: inputs.version_type == 'pr' && contains(github.event.pull_request.base.ref, 'release/')
+        uses: hoprnet/hopr-workflows/actions/multi-arch-manifest@multi-arch-manifest-v1
+        with:
+          registry: ${{ inputs.docker_gcp_registry }}
+          image: ${{ inputs.docker_image_name }}
+          version: latest-lts
+      - name: Create multi-arch docker manifest - release-main
+        if: inputs.version_type == 'release' && (github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'master')
+        uses: hoprnet/hopr-workflows/actions/multi-arch-manifest@multi-arch-manifest-v1
+        with:
+          registry: ${{ inputs.docker_gcp_registry }}
+          image: ${{ inputs.docker_image_name }}
+          version: release-main
+      - name: Create multi-arch docker manifest - release-lts
+        if: inputs.version_type == 'release' && contains(github.event.pull_request.base.ref, 'release/')
+        uses: hoprnet/hopr-workflows/actions/multi-arch-manifest@multi-arch-manifest-v1
+        with:
+          registry: ${{ inputs.docker_gcp_registry }}
+          image: ${{ inputs.docker_image_name }}
+          version: release-lts
+      - name: Determine DockerHub publishing condition
+        id: docker_hub
+        run: |
+          if [ "${{ inputs.version_type }}" = "release" ] && [ -n "${{ secrets.docker_hub_username }}" ] && [ -n "${{ secrets.docker_hub_token }}" ]; then
+            echo "publish_docker_hub=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "publish_docker_hub=false" | tee -a "$GITHUB_OUTPUT"
+          fi
       - name: Log in to Docker Hub
-        if: steps.docker_hub.outputs.publish_dockerhub == 'true'
+        if: steps.docker_hub.outputs.publish_docker_hub == 'true'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.docker_hub_username }}
           password: ${{ secrets.docker_hub_token }}
       - name: Create multi-arch docker manifest - Docker Hub - ${{ needs.build.outputs.docker_build_version }}
-        if: steps.docker_hub.outputs.publish_dockerhub == 'true'
+        if: steps.docker_hub.outputs.publish_docker_hub == 'true'
         uses: hoprnet/hopr-workflows/actions/multi-arch-manifest@multi-arch-manifest-v1
         with:
           registry: ${{ inputs.docker_hub_registry }}

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -221,9 +221,9 @@ jobs:
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
             set -euo pipefail
             echo "Publishing image ${GCP_DEBUG_IMAGE_NAME}"
-            if [[ "${{ inputs.docker_image_format }}" eq "skopeo" ]]; then
+            if [[ "${{ inputs.docker_image_format }}" == "skopeo" ]]; then
               skopeo --insecure-policy copy docker-archive:./result "docker://${GCP_DEBUG_IMAGE_NAME}"
-            elif [[ "${{ inputs.docker_image_format }}" eq "docker" ]]; then
+            elif [[ "${{ inputs.docker_image_format }}" == "docker" ]]; then
               docker tag ${{ inputs.docker_image_name }}:latest "${GCP_DEBUG_IMAGE_NAME}"
               docker push "${GCP_DEBUG_IMAGE_NAME}"
             fi

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -7,6 +7,7 @@ env:
   CARGO_TERM_COLOR: always
 permissions:
   contents: read
+  pull-requests: write
   id-token: write # Required for cosign keyless attestation and GCP Workload Identity
 on:
   workflow_call:

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -46,6 +46,11 @@ on:
         type: string
         default: "docker.io/hoprnet"
         description: "Docker registry to push the image to"
+      docker_image_format:
+        required: false
+        type: string
+        default: "docker"
+        description: "Format to use when pushing docker images: 'docker' or 'skopeo'"
       timeout_minutes:
         required: false
         type: number
@@ -156,23 +161,26 @@ jobs:
         run: |
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
             set -euo pipefail
-            echo "Publishing image to GCP Artifact Registry: ${GCP_IMAGE_NAME}"
-            skopeo --insecure-policy copy docker-archive:./result "docker://${GCP_IMAGE_NAME}"
-            echo "Published image to GCP Artifact Registry: ${GCP_IMAGE_NAME}"
+            fn publish_image() {
+              local target_image="${1}"
+              echo "Publishing image ${target_image}"
+              if [[ "${{ inputs.docker_image_format }}" eq "skopeo" ]]; then
+                skopeo --insecure-policy copy docker-archive:./result "docker://${target_image}"
+              elif [[ "${{ inputs.docker_image_format }}" eq "docker" ]]; then
+                docker tag ${{ inputs.docker_image_name }}:latest "${target_image}"
+                docker push "${target_image}"
+              fi
+              echo "Published image ${target_image}"
+            }
+            publish_image "${GCP_IMAGE_NAME}"
             if [[ "${{ steps.version.outputs.deploy_staging }}" == "true" && "${{ matrix.architecture }}" == "x86_64-linux" ]]; then
-              echo "Publishing staging image to GCP Artifact Registry: ${GCP_STAGING_IMAGE_NAME}"
-              skopeo --insecure-policy copy docker-archive:./result "docker://${GCP_STAGING_IMAGE_NAME}"
-              echo "Published staging image to GCP Artifact Registry: ${GCP_STAGING_IMAGE_NAME}"
+              publish_image "${GCP_STAGING_IMAGE_NAME}"
             fi
             if [[ "${{ inputs.version_type }}" == "pr" ]]; then
-              echo "Publishing latest image to GCP Artifact Registry: ${GCP_LATEST_IMAGE_NAME}"
-              skopeo --insecure-policy copy docker-archive:./result "docker://${GCP_LATEST_IMAGE_NAME}"
-              echo "Published latest image to GCP Artifact Registry: ${GCP_LATEST_IMAGE_NAME}"
+              publish_image "${GCP_LATEST_IMAGE_NAME}"
             fi
             if [[ "${{ steps.docker_hub.outputs.publish_docker_hub }}" == "true" ]]; then
-              echo "Publishing image to DockerHub: ${DOCKER_HUB_IMAGE_NAME}"
-              skopeo --insecure-policy copy docker-archive:./result "docker://${DOCKER_HUB_IMAGE_NAME}"
-              echo "Published image to DockerHub: ${DOCKER_HUB_IMAGE_NAME}"
+              publish_image "${DOCKER_HUB_IMAGE_NAME}"
             fi
           SKOPEO
         env:
@@ -188,9 +196,14 @@ jobs:
         run: |
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
             set -euo pipefail
-            echo "Publishing debug image to GCP Artifact Registry: ${GCP_DEBUG_IMAGE_NAME}"
-            skopeo --insecure-policy copy docker-archive:./result "docker://${GCP_DEBUG_IMAGE_NAME}"
-            echo "Published debug image to GCP Artifact Registry: ${GCP_DEBUG_IMAGE_NAME}"
+            echo "Publishing image ${GCP_DEBUG_IMAGE_NAME}"
+            if [[ "${{ inputs.docker_image_format }}" eq "skopeo" ]]; then
+              skopeo --insecure-policy copy docker-archive:./result "docker://${GCP_DEBUG_IMAGE_NAME}"
+            elif [[ "${{ inputs.docker_image_format }}" eq "docker" ]]; then
+              docker tag ${{ inputs.docker_image_name }}:latest "${GCP_DEBUG_IMAGE_NAME}"
+              docker push "${GCP_DEBUG_IMAGE_NAME}"
+            fi
+            echo "Published image ${GCP_DEBUG_IMAGE_NAME}"
           SKOPEO
         env:
           GCP_DEBUG_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -332,6 +332,7 @@ jobs:
           format: json
           exit-code: "${{ steps.docker.outputs.trivy_exit_code }}"
           ignore-unfixed: true
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
           vuln-type: "os,library"
           severity: "HIGH,CRITICAL"
           output: trivy.json

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -123,6 +123,11 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.source_branch }}
+      - name: Setup Nix
+        uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
+        with:
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
+          cachix_auth_token: "${{ secrets.cachix_auth_token }}"
       - name: Updates build version
         id: version
         uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v2
@@ -130,17 +135,6 @@ jobs:
           file: "${{ inputs.build_file }}"
           version_type: "${{ inputs.version_type }}"
           architecture: "${{ matrix.architecture }}"
-      - name: Setup GCP
-        id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
-        with:
-          google_credentials: ${{ secrets.gcp_service_account }}
-          login_artifact_registry: 'true'
-      - name: Setup Nix
-        uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
-        with:
-          cachix_cache_name: ${{ inputs.cachix_cache_name }}
-          cachix_auth_token: "${{ secrets.cachix_auth_token }}"
       - name: Determine DockerHub publishing condition
         id: docker_hub
         run: |
@@ -149,14 +143,23 @@ jobs:
           else
             echo "publish_docker_hub=false" | tee -a "$GITHUB_OUTPUT"
           fi
+      - name: Build docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
+        run: ${{ matrix.build_command }}
+      - name: Build debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
+        if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
+        run: ${{ matrix.build_debug_command }}
+      - name: Setup GCP
+        id: gcp
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
+        with:
+          google_credentials: ${{ secrets.gcp_service_account }}
+          login_artifact_registry: 'true'
       - name: Log in to DockerHub
         if: steps.docker_hub.outputs.publish_docker_hub == 'true'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.docker_hub_username }}
           password: ${{ secrets.docker_hub_token }}
-      - name: Build docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
-        run: ${{ matrix.build_command }}
       - name: Publish docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
         run: |
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
@@ -212,9 +215,6 @@ jobs:
           GCP_RELEASE_MAIN_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:release-main-${{ steps.version.outputs.docker_platform }}
           GCP_RELEASE_LTS_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:release-lts-${{ steps.version.outputs.docker_platform }}
           DOCKER_HUB_IMAGE_NAME: ${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
-      - name: Build debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
-        if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
-        run: ${{ matrix.build_debug_command }}
       - name: Publish debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
         if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
         run: |

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -277,6 +277,11 @@ jobs:
       pull-requests: write
       id-token: write # Required for cosign keyless attestation and GCP Workload Identity
     steps:
+      - name: Setup Nix
+        uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
+        with:
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
+          cachix_auth_token: "${{ secrets.cachix_auth_token }}"
       - name: Set up Docker
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
       - name: Install Cosign
@@ -326,16 +331,15 @@ jobs:
           fi
       - name: Run Trivy
         if: inputs.version_type == 'commit'
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # v0.34.1
-        with:
-          image-ref: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.platform.outputs.docker_build_version_platform }}
-          format: json
-          exit-code: "${{ steps.docker.outputs.trivy_exit_code }}"
-          ignore-unfixed: true
-          github-pat: ${{ secrets.GITHUB_TOKEN }}
-          vuln-type: "os,library"
-          severity: "HIGH,CRITICAL"
-          output: trivy.json
+        run: |
+          nix shell nixpkgs#trivy -c trivy image \
+            --exit-code "${{ steps.docker.outputs.trivy_exit_code }}" \
+            --ignore-unfixed \
+            --vuln-type "os,library" \
+            --severity "HIGH,CRITICAL" \
+            --format json \
+            --output trivy.json \
+            "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.platform.outputs.docker_build_version_platform }}"
       - name: Build Security Report Markdown
         if: inputs.version_type == 'commit'
         run: |

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -180,6 +180,7 @@ jobs:
               publish_image "${GCP_LATEST_IMAGE_NAME}"
             fi
             if [[ "${{ steps.docker_hub.outputs.publish_docker_hub }}" == "true" ]]; then
+              publish_image "${GCP_LATEST_RELEASE_IMAGE_NAME}"
               publish_image "${DOCKER_HUB_IMAGE_NAME}"
             fi
           SKOPEO
@@ -187,6 +188,7 @@ jobs:
           GCP_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
           GCP_STAGING_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:staging
           GCP_LATEST_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:latest-${{ steps.version.outputs.docker_platform }}
+          GCP_LATEST_RELEASE_IMAGE_NAME: ${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:latest-release-${{ steps.version.outputs.docker_platform }}
           DOCKER_HUB_IMAGE_NAME: ${{ inputs.docker_hub_registry }}/${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
       - name: Build debug docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_debug_version_platform }}
         if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
@@ -252,6 +254,13 @@ jobs:
           else
             echo "publish_dockerhub=false" | tee -a "$GITHUB_OUTPUT"
           fi
+      - name: Create multi-arch docker manifest - latest-release
+        if: inputs.version_type == 'release'
+        uses: hoprnet/hopr-workflows/actions/multi-arch-manifest@multi-arch-manifest-v1
+        with:
+          registry: ${{ inputs.docker_gcp_registry }}
+          image: ${{ inputs.docker_image_name }}
+          version: latest-release
       - name: Log in to Docker Hub
         if: steps.docker_hub.outputs.publish_dockerhub == 'true'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -342,13 +342,15 @@ jobs:
             "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.platform.outputs.docker_build_version_platform }}"
       - name: Build Security Report Markdown
         if: inputs.version_type == 'commit'
+        id: trivy_report
         run: |
           {
             echo "## 🔎 Trivy Security Report"
             echo ""
-            echo "| Target | Package | Installed | Severity | CVE |"
+            echo "| Target | Package  | Installed  | Severity | CVE |"
             echo "|--------|----------|------------|----------|-----|"
-
+          } > trivy-header.md
+          {
             jq -r '
               .Results[]?
               | select(.Vulnerabilities != null)
@@ -357,9 +359,16 @@ jobs:
               | "| \($target) | \(.PkgName) | \(.InstalledVersion) | \(.Severity) | \(.VulnerabilityID) |"
             ' trivy.json || echo "| - | Could not process Trivy results | - | - | - |"
 
-          } > trivy-comment.md
+          } > trivy-results.md
+          if [ -s trivy-results.md ]; then
+            cat trivy-header.md trivy-results.md > trivy-comment.md
+            echo "trivy_vulnerabilities_found=true" | tee -a $GITHUB_OUTPUT
+          else
+            echo "No vulnerabilities found or failed to process Trivy results" > trivy-comment.md
+            echo "trivy_vulnerabilities_found=false" | tee -a $GITHUB_OUTPUT
+          fi
       - name: Find existing Trivy comment
-        if: inputs.version_type == 'commit'
+        if: inputs.version_type == 'commit' && steps.trivy_report.outputs.trivy_vulnerabilities_found == 'true'
         id: find
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad #v4.0.0
         with:
@@ -368,7 +377,7 @@ jobs:
           body-includes: "## 🔎 Trivy Security Report"
 
       - name: Create or update Trivy comment
-        if: inputs.version_type == 'commit'
+        if: inputs.version_type == 'commit' && steps.trivy_report.outputs.trivy_vulnerabilities_found == 'true'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 #v5.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -466,7 +466,7 @@ jobs:
           rm -f "${GIT_CONFIG_GLOBAL}" || true
           echo "GIT_CONFIG_GLOBAL=" >> "${GITHUB_ENV}"
   deploy:
-    name: Deploy
+    name: Deploy Hoprnet
     needs: [ build, manifest, scan ]
     if: (needs.build.outputs.deploy_staging == 'true' || (vars.DEPLOY_STAGING_MERGED_PR == 'true' && inputs.version_type == 'pr')) && (inputs.deployment_namespace != '' && inputs.deployment_label_selector != '')
     runs-on: self-hosted-hoprnet-small

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -161,7 +161,7 @@ jobs:
         run: |
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
             set -euo pipefail
-            fn publish_image() {
+            publish_image() {
               local target_image="${1}"
               echo "Publishing image ${target_image}"
               if [[ "${{ inputs.docker_image_format }}" eq "skopeo" ]]; then

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -376,12 +376,11 @@ jobs:
           body-path: trivy-comment.md
           edit-mode: replace
       - name: Generate SBOM
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # v0.34.1
-        with:
-          scan-type: image
-          image-ref: ${{ steps.docker.outputs.gcp_docker_image }}
-          format: cyclonedx
-          output: sbom.json
+        run: |
+          nix shell nixpkgs#trivy -c trivy image \
+            --format cyclonedx \
+            --output sbom.json \
+            "${{ steps.docker.outputs.gcp_docker_image }}"
       - name: Attest SBOM on GCP Artifact Registry
         run: cosign attest --predicate "sbom.json" --type cyclonedx "${{ steps.docker.outputs.gcp_docker_digest }}"
         env:

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -164,9 +164,9 @@ jobs:
             publish_image() {
               local target_image="${1}"
               echo "Publishing image ${target_image}"
-              if [[ "${{ inputs.docker_image_format }}" eq "skopeo" ]]; then
+              if [[ "${{ inputs.docker_image_format }}" == "skopeo" ]]; then
                 skopeo --insecure-policy copy docker-archive:./result "docker://${target_image}"
-              elif [[ "${{ inputs.docker_image_format }}" eq "docker" ]]; then
+              elif [[ "${{ inputs.docker_image_format }}" == "docker" ]]; then
                 docker tag ${{ inputs.docker_image_name }}:latest "${target_image}"
                 docker push "${target_image}"
               fi

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -1,0 +1,72 @@
+#################################################################################
+# Pipeline to build libraries
+#################################################################################
+name: Build library
+
+on:
+  workflow_call:
+    inputs:
+      source_branch:
+        required: true
+        type: string
+      version_type:
+        required: true
+        type: string
+      architecture:
+        required: true
+        type: string
+      cachix_cache_name:
+        required: true
+        type: string
+        description: "Cachix cache name to use"
+      build_file:
+        required: false
+        type: string
+        default: "Cargo.toml"
+        description: "File to extract version from"
+      build_command:
+        required: true
+        type: string
+        description: "Command to build the binary"
+      timeout_minutes:
+        required: false
+        type: number
+        default: 60
+        description: "Timeout for the job in minutes"
+      runner:
+        required: true
+        type: string
+    secrets:
+      cachix_auth_token:
+        required: true
+concurrency:
+  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-${{ inputs.architecture }}-library
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}  
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.source_branch }}
+      - name: Setup Nix
+        uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
+        with:
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
+          cachix_auth_token: "${{ secrets.cachix_auth_token }}"
+      - name: Build library
+        shell: bash
+        run: ${{ inputs.build_command }}

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -9,9 +9,6 @@ on:
       source_branch:
         required: true
         type: string
-      version_type:
-        required: true
-        type: string
       architecture:
         required: true
         type: string

--- a/.github/workflows/cleanup-registry.yaml
+++ b/.github/workflows/cleanup-registry.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup GCP
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
           install_sdk: "true"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Compiles binaries for a specific architecture using Nix. It handles version nami
 ```yaml
 jobs:
   build:
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     with:
       source_branch: ${{ github.ref_name }}
       version_type: commit

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ jobs:
 - `cachix_cache_name` (Required): The name of the Cachix cache to use.
 - `build_file` (Optional): File to extract version from (Default: `Cargo.toml`).
 - `build_command` (Required): The command to execute the build.
-- `build_debug_command` (Optional): Additional build debug flavor to use.
 - `binary` (Required): The name of the binary to output.
 - `timeout_minutes` (Optional): Timeout for the job in minutes (Default: `60`).
 - `runner` (Required): The runner label to use for the job.
@@ -234,6 +233,43 @@ jobs:
 - `gcp_service_account` (Required): Google Cloud Service Account with permissions to upload artifacts.
 - `docker_hub_username` (Optional): Docker Hub username (Required for release builds).
 - `docker_hub_token` (Optional): Docker Hub token (Required for release builds).
+
+**Outputs:**
+
+- No outputs defined.
+
+### [Build Library](./.github/workflows/build-library.yaml)
+
+Compiles a library for a specific architecture using Nix. Unlike the binary workflow, it does not sign or upload artifacts — it only runs the build command.
+
+**Usage:**
+```yaml
+jobs:
+  build-library:
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v1
+    with:
+      source_branch: ${{ github.ref_name }}
+      version_type: commit
+      architecture: x86_64-linux
+      cachix_cache_name: hopr
+      build_command: nix build .#my-library-x86_64-linux
+      runner: self-hosted-hoprnet-bigger
+    secrets:
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+```
+
+**Inputs:**
+- `source_branch` (Required): Source branch to build the library from.
+- `version_type` (Required): The strategy for versioning (e.g., `commit`, `pr`, `release`).
+- `architecture` (Required): The target architecture (e.g., `x86_64-linux`).
+- `cachix_cache_name` (Required): The name of the Cachix cache to use.
+- `build_file` (Optional): File to extract version from (Default: `Cargo.toml`).
+- `build_command` (Required): The command to execute the build.
+- `timeout_minutes` (Optional): Timeout for the job in minutes (Default: `60`).
+- `runner` (Required): The runner label to use for the job.
+
+**Secrets:**
+- `cachix_auth_token` (Required): Auth token for Cachix cache.
 
 **Outputs:**
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ jobs:
       cachix_cache_name: "blokli"
       build_file: "bloklid/Cargo.toml"
       docker_image_name: "bloklid"
+      docker_image_format: skopeo
       deployment_namespace: blokli
       deployment_label_selector: app.kubernetes.io/name=blokli
     secrets:
@@ -118,6 +119,7 @@ jobs:
 - `cachix_cache_name` (Required): The name of the Cachix cache to use.
 - `build_file` (Optional): File to extract version from (Default: `Cargo.toml`).
 - `docker_image_name` (Required): The name of the image.
+- `docker_image_format`: (Optional): Type of format generated for the docker image: `docker` or `skopeo` (Default: `docker`).
 - `docker_gcp_registry` (Optional): Docker registry to push the image to (Default: `europe-west3-docker.pkg.dev/hoprassociation/docker-images`).
 - `docker_hub_registry` (Optional): Docker registry to push the image to (Default: `docker.io/hoprnet`).
 - `timeout_minutes` (Optional): Timeout for the job in minutes (Default: `60`).

--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v1
     with:
       source_branch: ${{ github.ref_name }}
-      version_type: commit
       architecture: x86_64-linux
       cachix_cache_name: hopr
       build_command: nix build .#my-library-x86_64-linux
@@ -260,7 +259,6 @@ jobs:
 
 **Inputs:**
 - `source_branch` (Required): Source branch to build the library from.
-- `version_type` (Required): The strategy for versioning (e.g., `commit`, `pr`, `release`).
 - `architecture` (Required): The target architecture (e.g., `x86_64-linux`).
 - `cachix_cache_name` (Required): The name of the Cachix cache to use.
 - `build_file` (Optional): File to extract version from (Default: `Cargo.toml`).

--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -23,7 +23,14 @@ runs:
         shell: bash
         id: versions
         run: |
-          current_version=$(grep -E '^version\s*=' ${{ inputs.file }} | awk -F\" '{print $2}')
+          if [[ "${{ inputs.file }}" =~ ^.*\.toml$ ]]; then
+            current_version=$(grep -E '^version\s*=' ${{ inputs.file }} | awk -F\" '{print $2}')
+          elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then
+            current_version=$(jq -r '.version' ${{ inputs.file }})
+          else
+            echo "Unsupported file type: ${{ inputs.file }}"
+            exit 1
+          fi
           echo "current_version=${current_version}" | tee -a "$GITHUB_OUTPUT"
           # Split pre-release if any
           IFS='-'
@@ -78,16 +85,19 @@ runs:
 
 
           # Update the version in the specified file
-          # capture group 1: version = "
-          # capture group 2: the version number
-          # capture group 3: "
-          sed -i.bak -E "s/(^version = \")([0-9]+\.[0-9]+\.[0-9]+)(-rc\.[0-9]+)?(\+.*)?(\")/\1${bump_version}\5/" ${{ inputs.file }}
-          rm ${{ inputs.file }}.bak
-          if [[ "${{ inputs.file }}" =~ .*Cargo\.toml$ ]]; then
-            nix develop --command cargo generate-lockfile
+          if [[ "${{ inputs.file }}" =~ .*\.toml$ ]]; then
+            sed -i.bak -E "s/(^version = \")([0-9]+\.[0-9]+\.[0-9]+)(-rc\.[0-9]+)?(\+.*)?(\")/\1${bump_version}\5/" ${{ inputs.file }}
+            rm "${{ inputs.file }}.bak"
+            if [[ "${{ inputs.file }}" =~ .*Cargo\.toml$ ]]; then
+              echo "Regenerating Cargo.lock file"
+              nix develop --command cargo generate-lockfile
+            fi
+          elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then
+            jq --arg bump_version "${bump_version}" '.version = $bump_version' ${{ inputs.file }} > "${{ inputs.file }}.tmp"
+            mv "${{ inputs.file }}.tmp" ${{ inputs.file }}
           fi
           echo "bump_version=${bump_version}" | tee -a "$GITHUB_OUTPUT"
-          lock_file=$(echo "${{ inputs.file }}" | sed 's/\.toml$/.lock/')
+          lock_file=$(echo "${{ inputs.file }}" | sed -E 's/\.(toml|json)$/.lock/')
           if [[ -f "$lock_file" ]]; then
             echo "commit_files=${{ inputs.file }} ${lock_file}" | tee -a "$GITHUB_OUTPUT"
           else

--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -90,7 +90,9 @@ runs:
             rm "${{ inputs.file }}.bak"
             if [[ "${{ inputs.file }}" =~ .*Cargo\.toml$ ]]; then
               echo "Regenerating Cargo.lock file"
-              nix develop --command cargo generate-lockfile
+              nix develop --command cargo metadata --no-deps --format-version 1 --manifest-path ${{ inputs.file }} \
+                | jq -r '.packages[] | select(.source == null) | .name' \
+                | xargs -I{} nix develop --command cargo update -p {}
             fi
           elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then
             jq --arg bump_version "${bump_version}" '.version = $bump_version' ${{ inputs.file }} > "${{ inputs.file }}.tmp"

--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -90,9 +90,9 @@ runs:
             rm "${{ inputs.file }}.bak"
             if [[ "${{ inputs.file }}" =~ .*Cargo\.toml$ ]]; then
               echo "Regenerating Cargo.lock file"
-              nix develop --command cargo metadata --no-deps --format-version 1 --manifest-path ${{ inputs.file }} \
+              nix develop --command bash -c "cargo metadata --no-deps --format-version 1 --manifest-path ${{ inputs.file }} \
                 | jq -r '.packages[] | select(.source == null) | .name' \
-                | xargs -I{} nix develop --command cargo update -p {}
+                | xargs -I{} cargo update -p {}"
             fi
           elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then
             jq --arg bump_version "${bump_version}" '.version = $bump_version' ${{ inputs.file }} > "${{ inputs.file }}.tmp"

--- a/actions/download-artifact-registry/action.yaml
+++ b/actions/download-artifact-registry/action.yaml
@@ -34,11 +34,13 @@ runs:
         shell: bash
         id: artifacts
         run: |
+          # Set gcloud config defaults to avoid repeating flags
+          gcloud config set project "${{ inputs.project }}"
+          gcloud config set artifacts/location "${{ inputs.region }}"
+          gcloud config set artifacts/repository "${{ inputs.repository }}"
+
           mkdir -p "${{ inputs.destination }}"
           if ! files=$(gcloud artifacts files list \
-            --project="${{ inputs.project }}" \
-            --location="${{ inputs.region }}" \
-            --repository="${{ inputs.repository }}" \
             --package="${{ inputs.package }}" \
             --version="${{ inputs.version }}" \
             --format=json | jq -r '.[] | .name'); then
@@ -54,9 +56,6 @@ runs:
             # Extract the filename from the full resource path (after the last ':')
             filename="${file##*:}"
             if ! gcloud artifacts generic download \
-              --project="${{ inputs.project }}" \
-              --location="${{ inputs.region }}" \
-              --repository="${{ inputs.repository }}" \
               --package="${{ inputs.package }}" \
               --version="${{ inputs.version }}" \
               --destination="${{ inputs.destination }}" \

--- a/actions/generate-release-notes/generate-release-notes.sh
+++ b/actions/generate-release-notes/generate-release-notes.sh
@@ -78,14 +78,12 @@ github_format_changelog() {
     local section_ci="\n### Automation\n\n"
     local section_documentation="\n### Documentation\n\n"
     local section_other="\n### Other\n\n"
-    
+
     local change_log_content="## What's Changed\n"
-    
+
     # Add summary header
     change_log_content+="\nThis release contains the following changes:\n\n"
-    change_log_content+="\n"
 
-    
     # Process each changelog entry
     for entry in "${changelog_entries[@]:-}"; do
         if [[ -z "$entry" ]]; then

--- a/actions/release-version/README.md
+++ b/actions/release-version/README.md
@@ -17,6 +17,8 @@ This action performs the following steps:
           file: Cargo.toml
           release_type: patch
           package_name: my-package
+          cachix_cache_name: my-repo
+          cachix_auth_token: ${{ cachix_auth_token }}
           zulip_email: ${{ secrets.ZULIP_EMAIL }}
           zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
           zulip_channel: "MyChannel"
@@ -36,7 +38,9 @@ This action performs the following steps:
 - `source_branch`: Source branch for release notes
 - `file`: The filepath to the version file (e.g. `Cargo.toml` or `package.json`).
 - `release_type`: The type of release that the project is about to bump to. Possible values are : `rc`, `patch`, `minor` and `major`.
-- `package_name`: Package name from Google Artifact Registry to download binaries from and publish in the release
+- `package_name`: Package name from Google Artifact Registry to download binaries from and publish in the release.
+- `cachix_cache_name` (Required): The name of the Cachix cache to use.
+- `cachix_auth_token` (Required): Auth token for Cachix cache.
 - `zulip_email`: Email of the user used to send Zulip notifications.
 - `zulip_api_key`: Api key of the zulip user.
 - `zulip_channel`: Zulip channel for notifications.

--- a/actions/release-version/README.md
+++ b/actions/release-version/README.md
@@ -34,7 +34,7 @@ This action performs the following steps:
 ## Inputs
 
 - `source_branch`: Source branch for release notes
-- `file`: The filepath to the `Cargo.toml` file.
+- `file`: The filepath to the version file (e.g. `Cargo.toml` or `package.json`).
 - `release_type`: The type of release that the project is about to bump to. Possible values are : `rc`, `patch`, `minor` and `major`.
 - `package_name`: Package name from Google Artifact Registry to download binaries from and publish in the release
 - `zulip_email`: Email of the user used to send Zulip notifications.

--- a/actions/release-version/README.md
+++ b/actions/release-version/README.md
@@ -11,7 +11,7 @@ This action performs the following steps:
 
 ```bash
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@release-version-v1
+        uses: hoprnet/hopr-workflows/actions/release-version@release-version-v2
         with:
           source_branch: main
           file: Cargo.toml

--- a/actions/release-version/README.md
+++ b/actions/release-version/README.md
@@ -18,7 +18,7 @@ This action performs the following steps:
           release_type: patch
           package_name: my-package
           cachix_cache_name: my-repo
-          cachix_auth_token: ${{ cachix_auth_token }}
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           zulip_email: ${{ secrets.ZULIP_EMAIL }}
           zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
           zulip_channel: "MyChannel"

--- a/actions/release-version/README.md
+++ b/actions/release-version/README.md
@@ -16,12 +16,12 @@ This action performs the following steps:
           source_branch: main
           file: Cargo.toml
           release_type: patch
+          package_name: my-package
           zulip_email: ${{ secrets.ZULIP_EMAIL }}
           zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
           zulip_channel: "MyChannel"
           zulip_topic: "Releases"
           gcp_service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_GITHUB_ACTIONS }}
-          attach_binaries: 'true'
           github_token: "${{ secrets.GH_RUNNER_TOKEN }}"
 ```
 
@@ -36,12 +36,13 @@ This action performs the following steps:
 - `source_branch`: Source branch for release notes
 - `file`: The filepath to the `Cargo.toml` file.
 - `release_type`: The type of release that the project is about to bump to. Possible values are : `rc`, `patch`, `minor` and `major`.
+- `gcp_service_account`: GCP Service Account JSON for Artifact Registry access
+- `package_name`: Google artifact registry package name
 - `zulip_email`: Email of the user used to send Zulip notifications.
 - `zulip_api_key`: Api key of the zulip user.
 - `zulip_channel`: Zulip channel for notifications.
 - `zulip_topic`: Zulip topic for notifications.
 - `gcp_service_account`: GCP Service Account JSON for Artifact Registry access
-- `attach_binaries`: Whether to attach binaries from Artifact Registry
 - `github_token`: GitHub Token from the Bot with permission to make direct commits into the branch
 
 ## Outputs

--- a/actions/release-version/README.md
+++ b/actions/release-version/README.md
@@ -36,8 +36,7 @@ This action performs the following steps:
 - `source_branch`: Source branch for release notes
 - `file`: The filepath to the `Cargo.toml` file.
 - `release_type`: The type of release that the project is about to bump to. Possible values are : `rc`, `patch`, `minor` and `major`.
-- `gcp_service_account`: GCP Service Account JSON for Artifact Registry access
-- `package_name`: Google artifact registry package name
+- `package_name`: Package name from Google Artifact Registry to download binaries from and publish in the release
 - `zulip_email`: Email of the user used to send Zulip notifications.
 - `zulip_api_key`: Api key of the zulip user.
 - `zulip_channel`: Zulip channel for notifications.

--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -66,7 +66,7 @@ runs:
       - name: Setup GCP
         if: inputs.gcp_service_account != ''
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ inputs.gcp_service_account }}
           login_artifact_registry: 'true'

--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -16,6 +16,12 @@ inputs:
     package_name:
         required: false
         description: "Google artifact registry package name"
+    cachix_cache_name:
+        required: true
+        description: "Cachix cache name to use"
+    cachix_auth_token:
+        required: true
+        description: "Cachix authentication token"
     zulip_api_key:
         description: Zulip API Key for notifications
         required: false
@@ -65,6 +71,11 @@ runs:
           google_credentials: ${{ inputs.gcp_service_account }}
           login_artifact_registry: 'true'
           install_sdk: 'true'
+      - name: Setup Nix
+        uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
+        with:
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
+          cachix_auth_token: "${{ inputs.cachix_auth_token }}"
       - name: Download binary files
         if: inputs.package_name != ''
         id: download

--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -13,6 +13,9 @@ inputs:
         description: Release type to bump (major, minor, patch, rc)
         required: false
         default: patch
+    package_name:
+        required: false
+        description: "Google artifact registry package name"
     zulip_api_key:
         description: Zulip API Key for notifications
         required: false
@@ -25,10 +28,6 @@ inputs:
     zulip_topic:
         description: Zulip topic for notifications
         required: false
-    attach_binaries:
-        description: Whether to attach binaries from Artifact Registry
-        required: false
-        default: 'true'
     gcp_service_account:
         description: GCP Service Account JSON for Artifact Registry access
         required: true
@@ -38,7 +37,7 @@ inputs:
 outputs:
     current_version:
         description: Current released version
-        value: ${{ steps.vars.outputs.current_version }}
+        value: ${{ steps.version.outputs.current_version }}
     bump_version:
         description: Version bumped
         value: ${{ steps.bump.outputs.bump_version }}
@@ -52,33 +51,27 @@ runs:
           fetch-depth: 0
           fetch-tags: true
           token: ${{ inputs.github_token }}
+      - name: Get version info
+        id: version
+        uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v2
+        with:
+          file: "${{ inputs.file }}"
+          version_type: release
       - name: Setup GCP
+        if: inputs.gcp_service_account != ''
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
         with:
           google_credentials: ${{ inputs.gcp_service_account }}
           login_artifact_registry: 'true'
           install_sdk: 'true'
-      - name: Get current version
-        shell: bash
-        id: vars
-        run: |
-          current_version=$(grep -E '^version\s*=' ${{ inputs.file }} | awk -F\" '{print $2}')
-          echo "current_version=${current_version}" | tee -a "$GITHUB_OUTPUT"
-          if [[ $current_version == *"-rc."* ]]; then
-            echo "prerelease=true" | tee -a $GITHUB_OUTPUT
-          else
-            echo "prerelease=false" | tee -a $GITHUB_OUTPUT
-          fi
-          repository=${{ github.repository }}
-          echo "repository=${repository##*/}" | tee -a $GITHUB_OUTPUT
       - name: Download binary files
-        if: inputs.attach_binaries == 'true'
+        if: inputs.package_name != ''
         id: download
         uses: hoprnet/hopr-workflows/actions/download-artifact-registry@download-artifact-registry-v1
         with:
-          package: ${{ steps.vars.outputs.repository }}
-          version: ${{ steps.vars.outputs.current_version }}
+          package: ${{ inputs.package_name }}
+          version: ${{ steps.version.outputs.current_version }}
       - name: Generate Release Notes
         uses: hoprnet/hopr-workflows/actions/generate-release-notes@generate-release-notes-v1
         with:
@@ -87,9 +80,9 @@ runs:
       - name: Create Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
-            tag_name: "v${{ steps.vars.outputs.current_version }}"
-            prerelease: ${{ steps.vars.outputs.prerelease }}
-            name: "v${{ steps.vars.outputs.current_version }}"
+            tag_name: "v${{ steps.version.outputs.current_version }}"
+            prerelease: ${{ steps.version.outputs.prerelease }}
+            name: "v${{ steps.version.outputs.current_version }}"
             body_path: ./release-notes.txt
             files: ${{ steps.download.outputs.downloaded_files || '' }}
       - name: Bump version
@@ -103,7 +96,7 @@ runs:
         if: ${{ inputs.zulip_api_key && inputs.zulip_email && inputs.zulip_channel && inputs.zulip_topic }}
         run: |
           {
-            echo "I'm thrilled to inform a new \`${{ github.repository }}\` version \`${{ steps.vars.outputs.current_version }}\` has been released."
+            echo "I'm thrilled to inform a new \`${{ github.repository }}\` version \`${{ steps.version.outputs.current_version }}\` has been released."
             echo ""
             cat ./release-notes.txt
           } > notification_message.txt

--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -30,7 +30,7 @@ inputs:
         required: false
     gcp_service_account:
         description: GCP Service Account JSON for Artifact Registry access
-        required: true
+        required: false
     github_token:
         description: GitHub Token from the Bot with permission to make direct commits into the branch
         required: true

--- a/actions/set-build-version/README.md
+++ b/actions/set-build-version/README.md
@@ -37,7 +37,7 @@ Updates the `version` of the project based on the type of build desired.
 - `debug_version`: Debug version with commit hash. Example: `1.2.3+debug.9a4f81a`. Set when the label `build-flavor-debug` is attached to the PR and the `version_type` is `commit`.
 - `pr_version`: Version with pull request number. Example: `1.2.3+pr.456`.
 - `release_version`: Release version. Example: `1.2.3`.
-- `prerelease`: Whether the version is a prerelease: `true` when the release_type is `rc`.
+- `prerelease`: Whether the version is a prerelease: `true` when the `version_type` is `release` and `current_version` contains `-rc.`.
 - `build_version`: Contains the value of output `commit_version`, `pr_version` or `release_version` depending on the `version_type` provided.
 - `docker_build_version`: Docker compatible build version. The character `+` is replaced by `-`. Platform agnostic tag. Example: `1.2.3-commit.9a4f81a`.
 - `docker_debug_version`: Docker compatible debug version. The character `+` is replaced by `-`. Platform agnostic tag. Example: `1.2.3-debug.9a4f81a`. Set when the label `build-flavor-debug` is attached to the PR and the `version_type` is `commit`.

--- a/actions/set-build-version/README.md
+++ b/actions/set-build-version/README.md
@@ -12,7 +12,7 @@ Updates the `version` of the project based on the type of build desired.
 ```bash
       - name: Updates build version
         id: version
-        uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v1
+        uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v2
         with:
           file: Cargo.toml
           version_type: 'commit'

--- a/actions/set-build-version/README.md
+++ b/actions/set-build-version/README.md
@@ -42,7 +42,7 @@ Updates the `version` of the project based on the type of build desired.
 - `docker_build_version`: Docker compatible build version. The character `+` is replaced by `-`. Platform agnostic tag. Example: `1.2.3-commit.9a4f81a`.
 - `docker_debug_version`: Docker compatible debug version. The character `+` is replaced by `-`. Platform agnostic tag. Example: `1.2.3-debug.9a4f81a`. Set when the label `build-flavor-debug` is attached to the PR and the `version_type` is `commit`.
 - `docker_build_version_platform`: Docker compatible build version. The character `+` is replaced by `-`. Platform specific tag. Example: `1.2.3-commit.9a4f81a-linux-amd64`.
-- `docker_debug_version_platform`: Docker compatible debug version. The character `+` is replaced by `-`. Platform specific tag. Example: `1.2.3-debug.9a4f81a-linux-amd64`. Set when the label `build-flavor-debug` is attached to the PR and the `version_type` is `commit`.
+- `docker_debug_version_platform`: Docker compatible debug version. The character `+` is replaced by `-`. Platform specific tag. Example: `1.2.3-debug.9a4f81a-linux-amd64`. Set when the label `build-flavor-debug` is attached to the PR and the `version_type` is `commit` and on `*-linux` architecture.
 - `docker_platform`: Docker platform based on architecture. Possible values: `linux-arm64` or `linux-amd64`.
 - `publish_artifact_registry`: Whether to publish the artifact in the Google Artifact registry. Enabled when the `version_type` is `pr` or `release` and when it's `commit` and the PR has the label `publish-binaries` attached.
 - `publish_github_release`: Whether to publish the artifact in the GitHub Release. Enabled when the `version_type` is `release`.

--- a/actions/set-build-version/README.md
+++ b/actions/set-build-version/README.md
@@ -37,6 +37,7 @@ Updates the `version` of the project based on the type of build desired.
 - `debug_version`: Debug version with commit hash. Example: `1.2.3+debug.9a4f81a`. Set when the label `build-flavor-debug` is attached to the PR and the `version_type` is `commit`.
 - `pr_version`: Version with pull request number. Example: `1.2.3+pr.456`.
 - `release_version`: Release version. Example: `1.2.3`.
+- `prerelease`: Whether the version is a prerelease: `true` when the release_type is `rc`.
 - `build_version`: Contains the value of output `commit_version`, `pr_version` or `release_version` depending on the `version_type` provided.
 - `docker_build_version`: Docker compatible build version. The character `+` is replaced by `-`. Platform agnostic tag. Example: `1.2.3-commit.9a4f81a`.
 - `docker_debug_version`: Docker compatible debug version. The character `+` is replaced by `-`. Platform agnostic tag. Example: `1.2.3-debug.9a4f81a`. Set when the label `build-flavor-debug` is attached to the PR and the `version_type` is `commit`.

--- a/actions/set-build-version/README.md
+++ b/actions/set-build-version/README.md
@@ -8,6 +8,21 @@ Updates the `version` of the project based on the type of build desired.
  - In pull requests merge: `x.y.z+pr.1234`
  - In close release: `x.y.z` . It basically does not modify anything
 
+
+## Version semantics
+
+| Version Type | Semver                   | Docker Platform Image               | Docker Manifest          | Use Case              |
+| ------------ | ------------------------ | ----------------------------------- | ------------------------ | --------------------- |
+| `commit`     | `<semver>+commit.<hash>` | `<semver>-commit.<hash>-<platform>` | `<semver>-commit.<hash>` | Development testing   |
+| `pr`         | `<semver>+pr.<number>`   | `<semver>-pr.<number>-<platform>`   | `<semver>-pr.<number>`   | Pre-merge validation  |
+| `release`    | `<semver>`               | `<semver>-<platform>`               | `<semver>`               | Production deployment |
+
+- `semver`: Refers to https://semver.org/ with <MAJOR>.<MINOR>.<PATCH>
+- `hash`: Refers to the short git commit hash
+- `number`: Refers to the GitHub pull request number
+- `platform`: Refers to the Docker specific platform: `linux-amd64` or `linux-arm64`
+
+
 ## Usage
 ```bash
       - name: Updates build version

--- a/actions/set-build-version/README.md
+++ b/actions/set-build-version/README.md
@@ -62,11 +62,11 @@ Production
 
 ### Choosing the Right Tag
 
-- **I want the latest code from active development** → `latest` or `latest-main`
-- **I want the latest stable release from active development** → `release-main`
-- **I want the latest code from the LTS branch** → `latest-lts`
-- **I want the latest stable release from the LTS branch** → `release-lts`
-- **I want what is currently running in production** → `stable`
+- I want the latest code from active development → `latest` or `latest-main`
+- I want the latest stable release from active development → `release-main`
+- I want the latest code from the LTS branch → `latest-lts`
+- I want the latest stable release from the LTS branch → `release-lts`
+- I want what is currently running in production → `stable`
 
 **Notes**
 

--- a/actions/set-build-version/README.md
+++ b/actions/set-build-version/README.md
@@ -23,6 +23,57 @@ Updates the `version` of the project based on the type of build desired.
 - `platform`: Refers to the Docker specific platform: `linux-amd64` or `linux-arm64`
 
 
+## Tags semantics
+
+Below is described the tagging convention used for Docker images in Hoprnet.
+
+### Branches
+
+|           Branch          |                 Purpose                                                |
+|---------------------------|------------------------------------------------------------------------|
+| `main`                    | Active development branch. All new features and fixes are merged here. |
+| `release/<MAJOR>.<MINOR>` | Long-term support branch. Receives only critical fixes and backports.  |
+
+### Tags
+
+| Tag            | Branch | Trigger          |                   Description                                           |
+|----------------|--------|------------------|-------------------------------------------------------------------------|
+| `latest`       | `main` | PR merged        | The most recent image built from `main`. Alias of `latest-main`.        |
+| `latest-main`  | `main` | PR merged        | The most recent image built from `main`. Same image as `latest`.        |
+| `latest-lts`   | `lts`  | PR merged        | The most recent image built from the `release/<MAJOR>.<MINOR>` branch.  |
+| `release-main` | `main` | Release cut      | The latest release published from `main`.                               |
+| `release-lts`  | `lts`  | Release cut      | The latest release published from the `release/<MAJOR>.<MINOR>` branch. |
+| `stable`       |   —    | Manual promotion | The image currently running in production.                              |
+
+### Tag Lifecycle
+
+```
+main branch
+├── PR merged  ──► latest, latest-main   (moves on every merge)
+└── Release cut ──► release-main          (moves on every release)
+
+release/<MAJOR>.<MINOR> branch
+├── PR merged  ──► latest-lts            (moves on every merge)
+└── Release cut ──► release-lts           (moves on every release)
+
+Production
+└── Manual promotion ──► stable           (moves only when explicitly promoted)
+```
+
+### Choosing the Right Tag
+
+- **I want the latest code from active development** → `latest` or `latest-main`
+- **I want the latest stable release from active development** → `release-main`
+- **I want the latest code from the LTS branch** → `latest-lts`
+- **I want the latest stable release from the LTS branch** → `release-lts`
+- **I want what is currently running in production** → `stable`
+
+**Notes**
+
+- `latest` and `latest-main` always point to the same image. `latest-main` is provided for explicitness.
+- All above tags move over time. For reproducible deployments, prefer pinning to an immutable tag (`<MAJOR>.<MINOR>.<PATCH>`) or a specific image digest (`@sha256:...`).
+- `stable` is the only tag that is promoted manually. All other tags are updated automatically by CI.
+
 ## Usage
 ```bash
       - name: Updates build version

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -101,7 +101,7 @@ runs:
             publish_github_release=true
             publish_artifact_registry=true
             if [[ $current_version == *"-rc."* ]]; then
-              echo "prerelease=true"
+              prerelease=true
             fi
           else
             echo "Invalid version type"
@@ -129,14 +129,17 @@ runs:
           # Generate Docker compatible version
           docker_build_version=${build_version/+/-}
           if [[ "${{ inputs.architecture }}" == "aarch64-linux" ]]; then
-            docker_build_version_platform="${docker_build_version}-linux-arm64"
             docker_platform="linux-arm64"
           elif [[ "${{ inputs.architecture }}" == "x86_64-linux" ]]; then
-            docker_build_version_platform="${docker_build_version}-linux-amd64"
             docker_platform="linux-amd64"
           else
+            # We are not supporting other architectures for docker images at the moment
+            # But we want to allow the action to be used for other architectures for non-docker builds, so we won't fail the action here. 
+            # Instead, we'll set the docker_platform to the input architecture and let the docker build step fail if it's not supported.
+            docker_platform="${{ inputs.architecture }}"            
             echo "Unsupported architecture: ${{ inputs.architecture }}"
           fi
+          docker_build_version_platform="${docker_build_version}-${docker_platform}"
           echo "current_version=${current_version}" | tee -a "$GITHUB_OUTPUT"
           echo "commit_version=${commit_version}" | tee -a "$GITHUB_OUTPUT"
           echo "pr_version=${pr_version}" | tee -a "$GITHUB_OUTPUT"

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -10,7 +10,7 @@ inputs:
         required: true
     architecture:
         description: 'Target architecture for the docker image'
-        required: true
+        required: false
         default: x86_64-linux
 outputs:
     current_version:
@@ -28,6 +28,9 @@ outputs:
     release_version:
         description: 'Release version'
         value: ${{ steps.versions.outputs.release_version }}
+    prerelease:
+        description: 'Whether the version is a prerelease'
+        value: ${{ steps.versions.outputs.prerelease }}
     build_version:
         description: 'Build version based on version type'
         value: ${{ steps.versions.outputs.build_version }}
@@ -65,13 +68,21 @@ runs:
         id: versions
         run: |
           echo "Gathering version from ${{ inputs.file }} and setting build version type to '${{ inputs.version_type }}'"
-          current_version=$(grep -E '^version\s*=' ${{ inputs.file }} | awk -F\" '{print $2}')
+          if [[ "${{ inputs.file }}" =~ ^.*\.toml$ ]]; then
+            current_version=$(grep -E '^version\s*=' ${{ inputs.file }} | awk -F\" '{print $2}')
+          elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then
+            current_version=$(jq -r '.version' ${{ inputs.file }})
+          else
+            echo "Unsupported file type: ${{ inputs.file }}"
+            exit 1
+          fi
           commit_version="$current_version+commit.$(git rev-parse --short HEAD)"
           pr_version="$current_version+pr.${{ github.event.pull_request.number }}"
           release_version="$current_version"
           publish_artifact_registry=false
           publish_github_release=false
           deploy_staging=false
+          prerelease=false
           if [[ "${{ inputs.version_type }}" == "commit" ]]; then
             build_version=${commit_version}
             if [ "${GITHUB_PR_LABEL_PUBLISH_BINARIES:-0}" == '1' ]; then
@@ -88,6 +99,9 @@ runs:
             build_version=${release_version}
             publish_github_release=true
             publish_artifact_registry=true
+            if [[ $current_version == *"-rc."* ]]; then
+              echo "prerelease=true"
+            fi
           else
             echo "Invalid version type"
             echo "Parameter version_type must be one of the following:"
@@ -127,6 +141,7 @@ runs:
           echo "commit_version=${commit_version}" | tee -a "$GITHUB_OUTPUT"
           echo "pr_version=${pr_version}" | tee -a "$GITHUB_OUTPUT"
           echo "release_version=${release_version}" | tee -a "$GITHUB_OUTPUT"
+          echo "prerelease=${prerelease}" | tee -a "$GITHUB_OUTPUT"
           echo "build_version=${build_version}" | tee -a "$GITHUB_OUTPUT"
           echo "docker_build_version=${docker_build_version}" | tee -a "$GITHUB_OUTPUT"
           echo "docker_build_version_platform=${docker_build_version_platform}" | tee -a "$GITHUB_OUTPUT"
@@ -135,11 +150,18 @@ runs:
           echo "publish_github_release=${publish_github_release}" | tee -a "$GITHUB_OUTPUT"
           echo "deploy_staging=${deploy_staging}" | tee -a "$GITHUB_OUTPUT"
       - name: Update build version
+        # Equivalent to:  inputs.version_type != 'release'
+        if: steps.versions.outputs.current_version != steps.versions.outputs.build_version
         shell: bash
         run: |
-          sed -i.bak -E "s/(^version = \")([0-9]+\.[0-9]+\.[0-9]+)(-rc\.[0-9]+)?(\+.*)?(\")/\1${{ steps.versions.outputs.build_version}}\5/" ${{ inputs.file }}
-          if [[ "${{ inputs.file }}" =~ .*Cargo\.toml$ ]]; then
-            echo "Regenerating Cargo.lock file"
-            nix develop --command cargo generate-lockfile
+          if [[ "${{ inputs.file }}" =~ .*\.toml$ ]]; then
+            sed -i.bak -E "s/(^version = \")([0-9]+\.[0-9]+\.[0-9]+)(-rc\.[0-9]+)?(\+.*)?(\")/\1${{ steps.versions.outputs.build_version}}\5/" ${{ inputs.file }}
+            rm "${{ inputs.file }}.bak"
+            if [[ "${{ inputs.file }}" =~ .*Cargo\.toml$ ]]; then
+              echo "Regenerating Cargo.lock file"
+              nix develop --command cargo generate-lockfile
+            fi
+          elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then
+            jq --arg build_version "${{ steps.versions.outputs.build_version }}" '.version = $build_version' ${{ inputs.file }} > "${{ inputs.file }}.tmp"
+            mv "${{ inputs.file }}.tmp" ${{ inputs.file }}
           fi
-          rm "${{ inputs.file }}.bak"

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -135,7 +135,6 @@ runs:
             docker_platform="linux-amd64"
           else
             echo "Unsupported architecture: ${{ inputs.architecture }}"
-            exit 1
           fi
           echo "current_version=${current_version}" | tee -a "$GITHUB_OUTPUT"
           echo "commit_version=${commit_version}" | tee -a "$GITHUB_OUTPUT"

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -158,7 +158,7 @@ runs:
             rm "${{ inputs.file }}.bak"
             if [[ "${{ inputs.file }}" =~ .*Cargo\.toml$ ]]; then
               echo "Regenerating Cargo.lock file"
-              nix develop --command cargo generate-lockfile
+              nix develop --command cargo generate-lockfile --manifest-path ${{ inputs.file }}
             fi
           elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then
             jq --arg build_version "${{ steps.versions.outputs.build_version }}" '.version = $build_version' ${{ inputs.file }} > "${{ inputs.file }}.tmp"

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -67,7 +67,6 @@ runs:
         shell: bash
         id: versions
         run: |
-          set -x
           echo "Gathering version from ${{ inputs.file }} and setting build version type to '${{ inputs.version_type }}'"
           if [[ "${{ inputs.file }}" =~ ^.*\.toml$ ]]; then
             current_version=$(grep -E '^version\s*=' ${{ inputs.file }} | awk -F\" '{print $2}')

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -67,6 +67,7 @@ runs:
         shell: bash
         id: versions
         run: |
+          set -x
           echo "Gathering version from ${{ inputs.file }} and setting build version type to '${{ inputs.version_type }}'"
           if [[ "${{ inputs.file }}" =~ ^.*\.toml$ ]]; then
             current_version=$(grep -E '^version\s*=' ${{ inputs.file }} | awk -F\" '{print $2}')

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -67,6 +67,7 @@ runs:
         shell: bash
         id: versions
         run: |
+          set -x
           echo "Gathering version from ${{ inputs.file }} and setting build version type to '${{ inputs.version_type }}'"
           if [[ "${{ inputs.file }}" =~ ^.*\.toml$ ]]; then
             current_version=$(grep -E '^version\s*=' ${{ inputs.file }} | awk -F\" '{print $2}')
@@ -161,7 +162,9 @@ runs:
             rm "${{ inputs.file }}.bak"
             if [[ "${{ inputs.file }}" =~ .*Cargo\.toml$ ]]; then
               echo "Regenerating Cargo.lock file"
-              nix develop --command cargo generate-lockfile --manifest-path ${{ inputs.file }}
+              nix develop --command cargo metadata --no-deps --format-version 1 --manifest-path ${{ inputs.file }} \
+                | jq -r '.packages[] | select(.source == null) | .name' \
+                | xargs -I{} nix develop --command cargo update -p {}
             fi
           elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then
             jq --arg build_version "${{ steps.versions.outputs.build_version }}" '.version = $build_version' ${{ inputs.file }} > "${{ inputs.file }}.tmp"

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -162,9 +162,9 @@ runs:
             rm "${{ inputs.file }}.bak"
             if [[ "${{ inputs.file }}" =~ .*Cargo\.toml$ ]]; then
               echo "Regenerating Cargo.lock file"
-              nix develop --command cargo metadata --no-deps --format-version 1 --manifest-path ${{ inputs.file }} \
+              nix develop --command bash -c "cargo metadata --no-deps --format-version 1 --manifest-path ${{ inputs.file }} \
                 | jq -r '.packages[] | select(.source == null) | .name' \
-                | xargs -I{} nix develop --command cargo update -p {}
+                | xargs -I{} cargo update -p {}"
             fi
           elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then
             jq --arg build_version "${{ steps.versions.outputs.build_version }}" '.version = $build_version' ${{ inputs.file }} > "${{ inputs.file }}.tmp"

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -77,9 +77,11 @@ runs:
             exit 1
           fi
           if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
-            commit_version="${current_version}+commit.${{ github.event.pull_request.merge_commit_sha }}"
+            sha="${{ github.event.pull_request.merge_commit_sha }}"
+            commit_version="${current_version}+commit.${sha:0:7}"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            commit_version="${current_version}+commit.${{ github.event.pull_request.head.sha }}"
+            sha="${{ github.event.pull_request.head.sha }}"
+            commit_version="${current_version}+commit.${sha:0:7}"
           else
             commit_version="${current_version}+commit.$(git rev-parse --short HEAD)"
           fi

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -78,13 +78,14 @@ runs:
           fi
           if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
             sha="${{ github.event.pull_request.merge_commit_sha }}"
-            commit_version="${current_version}+commit.${sha:0:7}"
+            commit_sha="${sha:0:7}"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             sha="${{ github.event.pull_request.head.sha }}"
-            commit_version="${current_version}+commit.${sha:0:7}"
+            commit_sha="${sha:0:7}"
           else
-            commit_version="${current_version}+commit.$(git rev-parse --short HEAD)"
+            commit_sha=$(git rev-parse --short HEAD)
           fi
+          commit_version="${current_version}+commit.${commit_sha}"
           pr_version="${current_version}+pr.${{ github.event.pull_request.number }}"
           release_version="${current_version}"
           publish_artifact_registry=false
@@ -121,7 +122,7 @@ runs:
 
           ## Debug build flavor
           if [[ "${{ inputs.version_type }}" == "commit" ]] && [[ "${GITHUB_PR_LABEL_BUILD_FLAVOR_DEBUG:-0}" == '1' ]]; then
-              debug_version="$current_version+debug.$(git rev-parse --short HEAD)"
+              debug_version="${current_version}+debug.${commit_sha}"
               docker_debug_version=${debug_version/+/-}
               if [[ "${{ inputs.architecture }}" == "aarch64-linux" ]]; then
                 docker_debug_version_platform="${docker_debug_version}-linux-arm64"

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -76,9 +76,15 @@ runs:
             echo "Unsupported file type: ${{ inputs.file }}"
             exit 1
           fi
-          commit_version="$current_version+commit.$(git rev-parse --short HEAD)"
-          pr_version="$current_version+pr.${{ github.event.pull_request.number }}"
-          release_version="$current_version"
+          if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
+            commit_version="${current_version}+commit.${{ github.event.pull_request.merge_commit_sha }}"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            commit_version="${current_version}+commit.${{ github.event.pull_request.head.sha }}"
+          else
+            commit_version="${current_version}+commit.$(git rev-parse --short HEAD)"
+          fi
+          pr_version="${current_version}+pr.${{ github.event.pull_request.number }}"
+          release_version="${current_version}"
           publish_artifact_registry=false
           publish_github_release=false
           deploy_staging=false

--- a/actions/setup-gcp/README.md
+++ b/actions/setup-gcp/README.md
@@ -7,7 +7,7 @@ This action compiles a set of tasks to install and authenticate against GCP
 ```bash
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v1
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v2
         with:
           google_credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_GITHUB_ACTIONS }}
           install_sdk: "true"
@@ -23,10 +23,13 @@ None
 ## Inputs
 
 - `google_credentials`: This is the Google service account in JSON format with permissions to interact from GitHub in GCP.
+- `workload_identity_provider`: The workload identity provider to authenticate on GCP
+- `service_account`: The service account for the workload identity provider on GCP
 - `install_sdk`: Determines if the GCloud cli command line needs to be installed.
 - `login_artifact_registry`: Determines if the service account needs to login in the Google Artifact registry to be able to publish new artifacts.
 - `login_gke`: Determines if the service account needs to be logged in into the Kubernetes cluster
 - `project`: Id of the GCP project where the Kubernetes cluster exists.
+- `registry`: Google Artifact Registry host
 
 ## Outputs
 

--- a/actions/setup-gcp/action.yaml
+++ b/actions/setup-gcp/action.yaml
@@ -3,7 +3,13 @@ description: Install GCP tools and authenticate
 inputs:
     google_credentials:
         description: Google credentials taken from secret GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY
-        required: true
+        required: false
+    workload_identity_provider:
+        description: Workload Identity Provider
+        required: false
+    service_account:
+        description: Service Account email
+        required: false
     install_sdk:
         description: Install SDK
         required: false
@@ -20,6 +26,10 @@ inputs:
         description: GCP Project name
         required: false
         default: hoprassociation
+    registry:
+        description: Artifact Registry URL
+        required: false
+        default: europe-west3-docker.pkg.dev
 outputs:
     access_token:
         description: GCP Access token
@@ -27,19 +37,40 @@ outputs:
 runs:
     using: composite
     steps:
-        - name: Set up Google Cloud Credentials
-          id: auth
+        - name: Authenticate in Google Cloud using Account Key JSON
+          if: inputs.google_credentials != ''
+          id: auth_credentials
           uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
           with:
               token_format: access_token
               credentials_json: ${{ inputs.google_credentials }}
+
+        - name: Authenticate in Google Cloud using Workload Identity
+          id: auth_workload_identity
+          if: inputs.workload_identity_provider != '' && inputs.service_account != ''
+          uses: google-github-actions/auth@v2
+          with:
+            workload_identity_provider: ${{ env.WIF_PROVIDER }}
+            service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+        - name: Get GCP Access Token
+          id: auth
+          shell: bash
+          run: |
+            if [ -n "${{ steps.auth_credentials.outputs.access_token }}" ]; then
+              echo "access_token=${{ steps.auth_credentials.outputs.access_token }}" | tee -a "$GITHUB_OUTPUT"
+            elif [ -n "${{ steps.auth_workload_identity.outputs.access_token }}" ]; then
+              echo "access_token=${{ steps.auth_workload_identity.outputs.access_token }}" | tee -a "$GITHUB_OUTPUT"
+            else
+              echo "No access token found" >&2
+              exit 1
+            fi
         - name: Set up Google Cloud SDK
           if: inputs.install_sdk == 'true'
           uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
           with:
               project_id: ${{ inputs.project }}
               install_components: beta
-        - name: Set up GCP
+        - name: Set up Kubernetes cluster variables
           id: variables
           if: inputs.login_gke == 'true'
           shell: bash
@@ -57,6 +88,6 @@ runs:
           if: inputs.login_artifact_registry == 'true'
           uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
           with:
-            registry: europe-west3-docker.pkg.dev
+            registry: ${{ inputs.registry }}
             username: oauth2accesstoken
             password: ${{ steps.auth.outputs.access_token }}

--- a/actions/setup-gcp/action.yaml
+++ b/actions/setup-gcp/action.yaml
@@ -37,7 +37,7 @@ outputs:
 runs:
     using: composite
     steps:
-        - name: Authenticate in Google Cloud using Account Key JSON
+        - name: Authenticate in Google Cloud using JSON Account Key
           if: inputs.google_credentials != ''
           id: auth_credentials
           uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3

--- a/actions/setup-gcp/action.yaml
+++ b/actions/setup-gcp/action.yaml
@@ -50,8 +50,8 @@ runs:
           if: inputs.workload_identity_provider != '' && inputs.service_account != ''
           uses: google-github-actions/auth@v2
           with:
-            workload_identity_provider: ${{ env.WIF_PROVIDER }}
-            service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+            workload_identity_provider: ${{ inputs.workload_identity_provider }}
+            service_account: ${{ inputs.service_account }}
         - name: Get GCP Access Token
           id: auth
           shell: bash

--- a/actions/setup-gcp/action.yaml
+++ b/actions/setup-gcp/action.yaml
@@ -50,6 +50,7 @@ runs:
           if: inputs.workload_identity_provider != '' && inputs.service_account != ''
           uses: google-github-actions/auth@v2
           with:
+            token_format: access_token
             workload_identity_provider: ${{ inputs.workload_identity_provider }}
             service_account: ${{ inputs.service_account }}
         - name: Get GCP Access Token

--- a/actions/upload-artifact-registry/action.yaml
+++ b/actions/upload-artifact-registry/action.yaml
@@ -34,9 +34,13 @@ runs:
         shell: bash
         id: artifacts
         run: |
-          source_path="${{ inputs.source }}"
+          # Set gcloud config defaults to avoid repeating flags
+          gcloud config set project "${{ inputs.project }}"
+          gcloud config set artifacts/location "${{ inputs.region }}"
+          gcloud config set artifacts/repository "${{ inputs.repository }}"
           
           # Validate source exists
+          source_path="${{ inputs.source }}"
           if [ ! -e "$source_path" ]; then
             echo "Error: Source path does not exist: $source_path"
             exit 1
@@ -59,11 +63,22 @@ runs:
             exit 1
           fi
 
+          # List existing files in the registry once
+          existing_files=$(gcloud artifacts files list \
+            --package="${{ inputs.package }}" \
+            --version="${{ inputs.version }}" \
+            --format="value(name)" 2>/dev/null || true)
+
           for artifact in "${files[@]}"; do
+            # Check if the file already exists in the cached list
+            if echo "$existing_files" | grep -q "${artifact}$"; then
+              echo "File ${artifact} already exists, deleting before re-upload..."
+              gcloud artifacts files delete \
+                "${artifact}" --quiet || {
+                  echo "Warning: Failed to delete existing ${artifact}, attempting upload anyway"
+                }
+            fi
             gcloud artifacts generic upload \
-              --project="${{ inputs.project }}" \
-              --location="${{ inputs.region }}" \
-              --repository="${{ inputs.repository }}" \
               --package="${{ inputs.package }}" \
               --version="${{ inputs.version }}" \
               --source="${source_dir}/${artifact}" || {

--- a/actions/upload-artifact-registry/action.yaml
+++ b/actions/upload-artifact-registry/action.yaml
@@ -71,10 +71,11 @@ runs:
 
           for artifact in "${files[@]}"; do
             # Check if the file already exists in the cached list
-            if echo "$existing_files" | grep -q "${artifact}$"; then
+            existing_name=$(echo "$existing_files" | grep "${artifact}$" || true)
+            if [ -n "$existing_name" ]; then
               echo "File ${artifact} already exists, deleting before re-upload..."
               gcloud artifacts files delete \
-                "${artifact}" --quiet || {
+                "${existing_name}" --quiet || {
                   echo "Warning: Failed to delete existing ${artifact}, attempting upload anyway"
                 }
             fi

--- a/justfile
+++ b/justfile
@@ -8,4 +8,3 @@ tag tagName:
     echo "Pushing updated tag to remote repository..."
     git push origin {{tagName}}
     echo "Tag {{tagName}} updated successfully."
-    


### PR DESCRIPTION
- Unify docker-build-image and docker-manifest in single workflow
- Added support to npm projects
- Fixes #11
- New tags created:
   - `set-build-version-v2`
   - `build-binaries-v2`
   - `build-docker-v1`
   - `release-version-v2`
   - `setup-gcp-v2`
- Tags updated:
   - `build-docker-image-v1` 
   - `bump-version-v1`
   - `download-artifact-registry-v1`
   - `upload-artifact-registry-v1`
   - `generate-release-notes-v1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-architecture Docker build pipeline: conditional publishing, multi-arch manifests, security scanning, SBOM generation, attestations, optional smoke tests, and gated staging deploys.

* **Improvements**
  * Version tooling supports TOML and JSON files and detects prereleases.
  * Artifact registry actions streamlined; single-file or directory uploads, duplicate handling, and centralized configuration.

* **Changes**
  * Release workflow: new package input; removed legacy binary-attachment option.
  * Build/version tooling: updated version action and optional architecture input.

* **Documentation**
  * Added usage docs for the Docker build workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->