### PR TITLE
feat(ci): add nix-action composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains a collection of custom GitHub Actions and Reusable Work
 - [Release Version](./actions/release-version/README.md): Creates a GitHub release
 - [Set Build Version](./actions/set-build-version/README.md): Updates project version before building
 - [Setup GCP](./actions/setup-gcp/README.md): Setup GCP tools and permissions
+- [Nix Action](./actions/nix-action/README.md): All-in-one CI step: harden runner, checkout, Nix setup, and command execution
 - [Setup Nix](./actions/setup-nix/README.md): Setup a Nix environment in the runner
 - [Setup Node Js](./actions/setup-node-js/README.md): Setup Node Js and Yarn
 - [Sign file](./actions/sign-file/README.md): Creates a GPG signature of the file and SHA256

--- a/actions/nix-action/README.md
+++ b/actions/nix-action/README.md
@@ -1,0 +1,33 @@
+# Nix Action
+
+Composite action that consolidates common CI boilerplate into a single step: harden runner, checkout, optional Nix install (via [setup-nix](../setup-nix/README.md)), optional Cachix setup, and command execution.
+
+## Usage
+
+```yaml
+steps:
+  - name: Run tests
+    uses: hoprnet/hopr-workflows/actions/nix-action@nix-action-v1
+    with:
+      repository: ${{ inputs.source_repo }}
+      ref: ${{ inputs.source_branch }}
+      use_cachix: "true"
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      command: nix build -L .#my-tests
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `command` | Yes | — | Shell command(s) to execute (supports multi-line) |
+| `repository` | No | `github.repository` | Repository to checkout |
+| `ref` | No | `github.ref` | Git ref to checkout |
+| `install_nix` | No | `"true"` | Whether to install Nix via `setup-nix` |
+| `use_cachix` | No | `"false"` | Whether to set up Cachix |
+| `cachix_cache_name` | No | `hoprnet` | Cachix cache name |
+| `cachix_auth_token` | No | `""` | Cachix authentication token |
+| `github_access_token` | No | `""` | GitHub token for Nix install |
+| `disable_sudo` | No | `"true"` | Disable sudo in harden-runner |
+| `persist_credentials` | No | `"false"` | Persist git credentials after checkout |

--- a/actions/nix-action/README.md
+++ b/actions/nix-action/README.md
@@ -9,8 +9,7 @@ steps:
   - name: Run tests
     uses: hoprnet/hopr-workflows/actions/nix-action@nix-action-v1
     with:
-      repository: ${{ inputs.source_repo }}
-      ref: ${{ inputs.source_branch }}
+      source_branch: ${{ inputs.source_branch }}
       use_cachix: "true"
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -22,8 +21,7 @@ steps:
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `command` | Yes | — | Shell command(s) to execute (supports multi-line) |
-| `repository` | No | `github.repository` | Repository to checkout |
-| `ref` | No | `github.ref` | Git ref to checkout |
+| `source_branch` | No | `main` | Git branch to checkout |
 | `install_nix` | No | `"true"` | Whether to install Nix via `setup-nix` |
 | `use_cachix` | No | `"false"` | Whether to set up Cachix |
 | `cachix_cache_name` | No | `hoprnet` | Cachix cache name |

--- a/actions/nix-action/README.md
+++ b/actions/nix-action/README.md
@@ -1,6 +1,6 @@
 # Nix Action
 
-Composite action that consolidates common CI boilerplate into a single step: harden runner, checkout, optional Nix install (via [setup-nix](../setup-nix/README.md)), optional Cachix setup, and command execution.
+Composite action that consolidates common CI boilerplate into a single step: harden runner, checkout, Nix/Cachix setup (via [setup-nix](../setup-nix/README.md)), and command execution.
 
 ## Usage
 
@@ -10,9 +10,7 @@ steps:
     uses: hoprnet/hopr-workflows/actions/nix-action@nix-action-v1
     with:
       source_branch: ${{ inputs.source_branch }}
-      use_cachix: "true"
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
       command: nix build -L .#my-tests
 ```
 
@@ -22,10 +20,7 @@ steps:
 |---|---|---|---|
 | `command` | Yes | — | Shell command(s) to execute (supports multi-line) |
 | `source_branch` | No | `main` | Git branch to checkout |
-| `install_nix` | No | `"true"` | Whether to install Nix via `setup-nix` |
-| `use_cachix` | No | `"false"` | Whether to set up Cachix |
-| `cachix_cache_name` | No | `hoprnet` | Cachix cache name |
-| `cachix_auth_token` | No | `""` | Cachix authentication token |
-| `github_access_token` | No | `""` | GitHub token for Nix install |
+| `cachix_cache_name` | No | `hoprnet` | Cachix cache name (passed to setup-nix) |
+| `cachix_auth_token` | No | `""` | Cachix authentication token (passed to setup-nix) |
 | `disable_sudo` | No | `"true"` | Disable sudo in harden-runner |
 | `persist_credentials` | No | `"false"` | Persist git credentials after checkout |

--- a/actions/nix-action/action.yaml
+++ b/actions/nix-action/action.yaml
@@ -1,7 +1,7 @@
 name: Nix Action
 description: >
   Composite action that handles the common CI boilerplate: harden runner,
-  checkout, optional Nix install, optional Cachix setup, and command execution.
+  checkout, Nix/Cachix setup (via setup-nix), and command execution.
 
 inputs:
   command:
@@ -11,24 +11,12 @@ inputs:
     description: Git branch to checkout
     required: false
     default: main
-  install_nix:
-    description: Whether to install Nix (set to false for self-hosted runners with Nix pre-installed)
-    required: false
-    default: "true"
-  use_cachix:
-    description: Whether to set up Cachix
-    required: false
-    default: "false"
   cachix_cache_name:
-    description: Cachix cache name
+    description: Cachix cache name (passed to setup-nix)
     required: false
     default: hoprnet
   cachix_auth_token:
-    description: Cachix authentication token
-    required: false
-    default: ""
-  github_access_token:
-    description: GitHub token for Nix install
+    description: Cachix authentication token (passed to setup-nix)
     required: false
     default: ""
   disable_sudo:
@@ -56,11 +44,10 @@ runs:
         ref: ${{ inputs.source_branch }}
 
     - name: Setup Nix
-      if: inputs.install_nix == 'true'
       uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
       with:
-        cachix_cache_name: ${{ inputs.use_cachix == 'true' && inputs.cachix_cache_name || '' }}
-        cachix_auth_token: ${{ inputs.use_cachix == 'true' && inputs.cachix_auth_token || '' }}
+        cachix_cache_name: ${{ inputs.cachix_cache_name }}
+        cachix_auth_token: ${{ inputs.cachix_auth_token }}
 
     - name: Run command
       shell: bash

--- a/actions/nix-action/action.yaml
+++ b/actions/nix-action/action.yaml
@@ -60,21 +60,12 @@ runs:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
 
-    - name: Install Nix
+    - name: Setup Nix
       if: inputs.install_nix == 'true'
-      uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
+      uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
       with:
-        github_access_token: ${{ inputs.github_access_token }}
-
-    - name: Setup Cachix
-      if: inputs.use_cachix == 'true'
-      uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
-      continue-on-error: true
-      with:
-        name: ${{ inputs.cachix_cache_name }}
-        authToken: ${{ inputs.cachix_auth_token }}
-      env:
-        USER: runner
+        cachix_cache_name: ${{ inputs.use_cachix == 'true' && inputs.cachix_cache_name || '' }}
+        cachix_auth_token: ${{ inputs.use_cachix == 'true' && inputs.cachix_auth_token || '' }}
 
     - name: Run command
       shell: bash

--- a/actions/nix-action/action.yaml
+++ b/actions/nix-action/action.yaml
@@ -7,14 +7,10 @@ inputs:
   command:
     description: Shell command(s) to execute (supports multi-line)
     required: true
-  repository:
-    description: Repository to checkout
+  source_branch:
+    description: Git branch to checkout
     required: false
-    default: ${{ github.repository }}
-  ref:
-    description: Git ref to checkout
-    required: false
-    default: ${{ github.ref }}
+    default: main
   install_nix:
     description: Whether to install Nix (set to false for self-hosted runners with Nix pre-installed)
     required: false
@@ -57,8 +53,7 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: ${{ inputs.persist_credentials }}
-        repository: ${{ inputs.repository }}
-        ref: ${{ inputs.ref }}
+        ref: ${{ inputs.source_branch }}
 
     - name: Setup Nix
       if: inputs.install_nix == 'true'

--- a/actions/nix-action/action.yaml
+++ b/actions/nix-action/action.yaml
@@ -1,0 +1,81 @@
+name: Nix Action
+description: >
+  Composite action that handles the common CI boilerplate: harden runner,
+  checkout, optional Nix install, optional Cachix setup, and command execution.
+
+inputs:
+  command:
+    description: Shell command(s) to execute (supports multi-line)
+    required: true
+  repository:
+    description: Repository to checkout
+    required: false
+    default: ${{ github.repository }}
+  ref:
+    description: Git ref to checkout
+    required: false
+    default: ${{ github.ref }}
+  install_nix:
+    description: Whether to install Nix (set to false for self-hosted runners with Nix pre-installed)
+    required: false
+    default: "true"
+  use_cachix:
+    description: Whether to set up Cachix
+    required: false
+    default: "false"
+  cachix_cache_name:
+    description: Cachix cache name
+    required: false
+    default: hoprnet
+  cachix_auth_token:
+    description: Cachix authentication token
+    required: false
+    default: ""
+  github_access_token:
+    description: GitHub token for Nix install
+    required: false
+    default: ""
+  disable_sudo:
+    description: Whether to disable sudo in harden-runner
+    required: false
+    default: "true"
+  persist_credentials:
+    description: Whether to persist git credentials after checkout
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+      with:
+        disable-sudo: ${{ inputs.disable_sudo }}
+        egress-policy: audit
+
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: ${{ inputs.persist_credentials }}
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.ref }}
+
+    - name: Install Nix
+      if: inputs.install_nix == 'true'
+      uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
+      with:
+        github_access_token: ${{ inputs.github_access_token }}
+
+    - name: Setup Cachix
+      if: inputs.use_cachix == 'true'
+      uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
+      continue-on-error: true
+      with:
+        name: ${{ inputs.cachix_cache_name }}
+        authToken: ${{ inputs.cachix_auth_token }}
+      env:
+        USER: runner
+
+    - name: Run command
+      shell: bash
+      run: ${{ inputs.command }}

--- a/actions/setup-nix/action.yaml
+++ b/actions/setup-nix/action.yaml
@@ -1,5 +1,8 @@
 name: Setup Nix
-description: Setup Nix environment
+# DEPRECATED: Use hoprnet/hopr-workflows/actions/nix-action instead.
+# This action only handles nix install + cachix. nix-action also includes
+# harden-runner, checkout, and command execution.
+description: "[DEPRECATED] Setup Nix environment — use nix-action instead"
 inputs:
     cachix_cache_name:
         description: Name of the Cachix cache to use

--- a/actions/setup-nix/action.yaml
+++ b/actions/setup-nix/action.yaml
@@ -1,8 +1,5 @@
 name: Setup Nix
-# DEPRECATED: Use hoprnet/hopr-workflows/actions/nix-action instead.
-# This action only handles nix install + cachix. nix-action also includes
-# harden-runner, checkout, and command execution.
-description: "[DEPRECATED] Setup Nix environment — use nix-action instead"
+description: Setup Nix environment
 inputs:
     cachix_cache_name:
         description: Name of the Cachix cache to use


### PR DESCRIPTION
## Summary
- Add new `actions/nix-action` composite action that consolidates the common CI boilerplate (harden-runner, checkout, nix install, cachix, command execution) into a single configurable step
- Mark `actions/setup-nix` as deprecated in favor of the new action
- Configurable inputs: `install_nix`, `use_cachix`, `repository`, `ref`, `command`, `disable_sudo`, `persist_credentials`

This action is consumed by PRs in [hoprnet](https://github.com/hoprnet/hoprnet) and [hopr-api](https://github.com/hoprnet/hopr-api) to eliminate ~330 lines of duplicated workflow YAML.

## Test plan
- [ ] Merge this PR and tag as `nix-action-v1`
- [ ] Verify hoprnet PR CI passes with the new action
- [ ] Verify hopr-api PR CI passes with the new action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Nix Action" that consolidates runner hardening, repository checkout, Nix/Cachix setup, and custom command execution into a single workflow step with configurable inputs (branch, Cachix credentials, runner hardening and credential behavior).

* **Documentation**
  * Added user documentation and examples showing how to use and configure the Nix Action and its supported inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->