### PR TITLE
feat(ci): add reusable checks, tests, and zizmor workflows

### DIFF
--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -1,0 +1,54 @@
+---
+################################################################################
+# Reusable zizmor security check pipeline
+#
+# Runs zizmor to scan GitHub Actions workflows for security issues and
+# uploads the results as a SARIF file to the GitHub Security tab.
+#
+# Note: Callers must declare `security-events: write` permission at the
+# job level for the SARIF upload to succeed.
+################################################################################
+name: Zizmor
+
+on:
+  workflow_call:
+    inputs:
+      source_branch:
+        required: true
+        type: string
+      runner:
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      zizmor_command:
+        required: false
+        type: string
+        default: 'nix develop -L .#ci -c bash -c "zizmor --format sarif . > results.sarif"'
+    secrets:
+      cachix_auth_token:
+        required: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Run zizmor
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source_branch: ${{ inputs.source_branch }}
+          cachix_auth_token: ${{ secrets.cachix_auth_token }}
+          command: ${{ inputs.zizmor_command }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -5,8 +5,9 @@
 # Runs zizmor to scan GitHub Actions workflows for security issues and
 # uploads the results as a SARIF file to the GitHub Security tab.
 #
-# Note: Callers must declare `security-events: write` permission at the
-# job level for the SARIF upload to succeed.
+# This workflow declares its own `security-events: write` permission at
+# the job level for the SARIF upload. No additional permissions are
+# required from the caller.
 ################################################################################
 name: Zizmor
 

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -46,6 +46,7 @@ jobs:
         with:
           source_branch: ${{ inputs.source_branch }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
+          persist_credentials: "true"
           command: ${{ inputs.zizmor_command }}
 
       - name: Upload SARIF file

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -42,11 +42,11 @@ jobs:
       - name: Run zizmor
         uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          NIX_CONFIG: "access-tokens = github.com=${{ github.token }}"
         with:
           source_branch: ${{ inputs.source_branch }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
-          persist_credentials: "true"
           command: ${{ inputs.zizmor_command }}
 
       - name: Upload SARIF file

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,97 @@
+---
+################################################################################
+# Reusable check pipeline
+#
+# Runs configurable code-quality checks (pre-commit, lint, deps, audit)
+# via a matrix strategy with per-check enable/disable toggles and command
+# overrides.
+################################################################################
+name: Checks
+
+on:
+  workflow_call:
+    inputs:
+      source_branch:
+        required: true
+        type: string
+      pre_commit:
+        required: false
+        type: boolean
+        default: true
+      lint:
+        required: false
+        type: boolean
+        default: true
+      deps:
+        required: false
+        type: boolean
+        default: true
+      audit:
+        required: false
+        type: boolean
+        default: true
+      pre_commit_command:
+        required: false
+        type: string
+        default: "nix build -L .#pre-commit-check"
+      lint_command:
+        required: false
+        type: string
+        default: "nix run -L .#check"
+      deps_command:
+        required: false
+        type: string
+        default: 'nix develop .#ci -c bash -c "cargo machete && cargo shear"'
+      audit_command:
+        required: false
+        type: string
+        default: "nix run .#audit"
+      runner_small:
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      runner_large:
+        required: false
+        type: string
+        default: "ubuntu-latest"
+    secrets:
+      cachix_auth_token:
+        required: true
+
+jobs:
+  check:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Pre-commit
+            enabled: ${{ inputs.pre_commit }}
+            runner: ${{ inputs.runner_small }}
+            timeout: 15
+            command: ${{ inputs.pre_commit_command }}
+          - name: Lint
+            enabled: ${{ inputs.lint }}
+            runner: ${{ inputs.runner_large }}
+            timeout: 30
+            command: ${{ inputs.lint_command }}
+          - name: Deps
+            enabled: ${{ inputs.deps }}
+            runner: ${{ inputs.runner_large }}
+            timeout: 10
+            command: ${{ inputs.deps_command }}
+          - name: Audit
+            enabled: ${{ inputs.audit }}
+            runner: ${{ inputs.runner_large }}
+            timeout: 15
+            command: ${{ inputs.audit_command }}
+    steps:
+      - name: Run ${{ matrix.name }}
+        if: matrix.enabled
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
+        with:
+          source_branch: ${{ inputs.source_branch }}
+          cachix_auth_token: ${{ secrets.cachix_auth_token }}
+          command: ${{ matrix.command }}

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -58,11 +58,15 @@ on:
       cachix_auth_token:
         required: true
 
+permissions: {}
+
 jobs:
   check:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ matrix.timeout }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,174 @@
+---
+################################################################################
+# Reusable test + coverage pipeline
+#
+# Tests and benchmarks run concurrently.
+# Coverage runs after all tests pass.
+################################################################################
+name: Tests
+
+on:
+  workflow_call:
+    inputs:
+      source_branch:
+        required: true
+        type: string
+      unit_tests:
+        required: false
+        type: boolean
+        default: true
+      integration_tests:
+        required: false
+        type: boolean
+        default: false
+      nightly_tests:
+        required: false
+        type: boolean
+        default: false
+      benchmarks:
+        required: false
+        type: boolean
+        default: false
+      coverage:
+        required: false
+        type: boolean
+        default: false
+      unit_test_command:
+        required: false
+        type: string
+        default: "nix build -L .#test-unit"
+      integration_test_command:
+        required: false
+        type: string
+        default: "nix develop -c cargo nextest run --test '*' -j 1"
+      nightly_test_command:
+        required: false
+        type: string
+        default: "nix build -L .#test-nightly"
+      benchmark_command:
+        required: false
+        type: string
+        default: "nix build .#bench-build"
+      unit_coverage_command:
+        required: false
+        type: string
+        default: |
+          nix build -L .#coverage-unit
+          cp result coverage.lcov
+      integration_coverage_command:
+        required: false
+        type: string
+        default: |
+          nix develop .#coverage -c cargo llvm-cov nextest \
+            --workspace \
+            --test '*' \
+            --lcov --output-path coverage.lcov \
+            -j 1
+      runner:
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      test_timeout:
+        required: false
+        type: number
+        default: 60
+      benchmark_timeout:
+        required: false
+        type: number
+        default: 20
+      coverage_timeout:
+        required: false
+        type: number
+        default: 60
+    secrets:
+      cachix_auth_token:
+        required: true
+      codecov_token:
+        required: false
+
+env:
+  RUST_BACKTRACE: "1"
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  # ── Tests + Benchmarks (concurrent) ────────────────────────────────────────
+  test:
+    name: ${{ matrix.name }}
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.test_timeout }}
+    env:
+      CI: "true"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Unit
+            enabled: ${{ inputs.unit_tests }}
+            command: ${{ inputs.unit_test_command }}
+          - name: Integration
+            enabled: ${{ inputs.integration_tests }}
+            command: ${{ inputs.integration_test_command }}
+          - name: Unit Nightly
+            enabled: ${{ inputs.nightly_tests }}
+            command: ${{ inputs.nightly_test_command }}
+    steps:
+      - name: Run ${{ matrix.name }}
+        if: matrix.enabled
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
+        with:
+          source_branch: ${{ inputs.source_branch }}
+          cachix_auth_token: ${{ secrets.cachix_auth_token }}
+          command: ${{ matrix.command }}
+
+  build-benchmarks:
+    name: Benchmark
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.benchmark_timeout }}
+    if: inputs.benchmarks && github.event_name == 'merge_group'
+    steps:
+      - name: Build benchmarks
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
+        with:
+          source_branch: ${{ inputs.source_branch }}
+          cachix_auth_token: ${{ secrets.cachix_auth_token }}
+          command: ${{ inputs.benchmark_command }}
+
+  # ── Coverage (after tests pass) ────────────────────────────────────────────
+  coverage:
+    name: Coverage / ${{ matrix.name }}
+    needs: [test]
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.coverage_timeout }}
+    if: inputs.coverage && (github.event_name == 'push' || (github.event.pull_request.draft == false))
+    env:
+      CI: "true"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Unit
+            enabled: ${{ inputs.unit_tests }}
+            command: ${{ inputs.unit_coverage_command }}
+            flag: unit
+          - name: Integration
+            enabled: ${{ inputs.integration_tests }}
+            command: ${{ inputs.integration_coverage_command }}
+            flag: integration
+    steps:
+      - name: Generate ${{ matrix.name }} report
+        if: matrix.enabled
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
+        with:
+          source_branch: ${{ inputs.source_branch }}
+          cachix_auth_token: ${{ secrets.cachix_auth_token }}
+          command: ${{ matrix.command }}
+
+      - name: Upload ${{ matrix.name }} report
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        if: >-
+          matrix.enabled && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+        with:
+          files: coverage.lcov
+          flags: ${{ matrix.flag }}
+          fail_ci_if_error: true
+          token: ${{ secrets.codecov_token }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ on:
       integration_test_command:
         required: false
         type: string
-        default: "nix develop -c cargo nextest run --test '*' -j 1"
+        default: "nix develop -c cargo nextest run --no-pager --test '*' -j 1"
       nightly_test_command:
         required: false
         type: string

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ on:
       integration_test_command:
         required: false
         type: string
-        default: "nix develop -c cargo nextest run --no-pager --test '*' -j 1"
+        default: "nix develop -c cargo nextest run --test '*' -j 1"
       nightly_test_command:
         required: false
         type: string
@@ -62,7 +62,7 @@ on:
         required: false
         type: string
         default: |
-          nix develop .#coverage -c cargo llvm-cov nextest --no-pager \
+          nix develop .#coverage -c cargo llvm-cov nextest \
             --workspace \
             --test '*' \
             --lcov --output-path coverage.lcov \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ on:
       integration_test_command:
         required: false
         type: string
-        default: "nix develop -c env NEXTEST_HIDE_PROGRESS_BAR=1 cargo nextest run --test '*' -j 1"
+        default: "nix build -L .#test-integration"
       nightly_test_command:
         required: false
         type: string
@@ -55,18 +55,11 @@ on:
       unit_coverage_command:
         required: false
         type: string
-        default: |
-          nix build -L .#coverage-unit
-          cp result coverage.lcov
+        default: "nix run .#coverage-unit"
       integration_coverage_command:
         required: false
         type: string
-        default: |
-          nix develop .#coverage -c env NEXTEST_HIDE_PROGRESS_BAR=1 cargo llvm-cov nextest \
-            --workspace \
-            --test '*' \
-            --lcov --output-path coverage.lcov \
-            -j 1
+        default: "nix run .#coverage-integration"
       runner:
         required: false
         type: string

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ on:
       integration_test_command:
         required: false
         type: string
-        default: "nix develop -c cargo nextest run --no-pager --show-progress=none --test '*' -j 1"
+        default: "nix develop -c env NEXTEST_HIDE_PROGRESS_BAR=1 cargo nextest run --test '*' -j 1"
       nightly_test_command:
         required: false
         type: string
@@ -62,8 +62,7 @@ on:
         required: false
         type: string
         default: |
-          nix develop .#coverage -c cargo llvm-cov nextest \
-            --no-pager --show-progress=none \
+          nix develop .#coverage -c env NEXTEST_HIDE_PROGRESS_BAR=1 cargo llvm-cov nextest \
             --workspace \
             --test '*' \
             --lcov --output-path coverage.lcov \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,11 +55,15 @@ on:
       unit_coverage_command:
         required: false
         type: string
-        default: "nix run .#coverage-unit"
+        default: |
+          nix build -L .#coverage-unit
+          cp result coverage.lcov
       integration_coverage_command:
         required: false
         type: string
-        default: "nix run .#coverage-integration"
+        default: |
+          nix build -L .#coverage-integration
+          cp result coverage.lcov
       runner:
         required: false
         type: string

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ on:
       integration_test_command:
         required: false
         type: string
-        default: "nix develop -c cargo nextest run --no-pager --test '*' -j 1"
+        default: "nix develop -c cargo nextest run --no-pager --show-progress=none --test '*' -j 1"
       nightly_test_command:
         required: false
         type: string
@@ -63,6 +63,7 @@ on:
         type: string
         default: |
           nix develop .#coverage -c cargo llvm-cov nextest \
+            --no-pager --show-progress=none \
             --workspace \
             --test '*' \
             --lcov --output-path coverage.lcov \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,9 @@
 #
 # Tests and benchmarks run concurrently.
 # Coverage runs after all tests pass.
+#
+# When `coverage` is enabled, the `codecov_token` secret must be provided
+# for the upload to succeed.
 ################################################################################
 name: Tests
 
@@ -40,7 +43,7 @@ on:
       integration_test_command:
         required: false
         type: string
-        default: "nix develop -c cargo nextest run --test '*' -j 1"
+        default: "nix develop -c cargo nextest run --no-pager --test '*' -j 1"
       nightly_test_command:
         required: false
         type: string
@@ -59,7 +62,7 @@ on:
         required: false
         type: string
         default: |
-          nix develop .#coverage -c cargo llvm-cov nextest \
+          nix develop .#coverage -c cargo llvm-cov nextest --no-pager \
             --workspace \
             --test '*' \
             --lcov --output-path coverage.lcov \
@@ -86,6 +89,8 @@ on:
       codecov_token:
         required: false
 
+permissions: {}
+
 env:
   RUST_BACKTRACE: "1"
   FOUNDRY_PROFILE: ci
@@ -96,6 +101,8 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.test_timeout }}
+    permissions:
+      contents: read
     env:
       CI: "true"
     strategy:
@@ -124,6 +131,8 @@ jobs:
     name: Benchmark
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.benchmark_timeout }}
+    permissions:
+      contents: read
     if: inputs.benchmarks && github.event_name == 'merge_group'
     steps:
       - name: Build benchmarks
@@ -139,6 +148,8 @@ jobs:
     needs: [test]
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.coverage_timeout }}
+    permissions:
+      contents: read
     if: inputs.coverage && (github.event_name == 'push' || (github.event.pull_request.draft == false))
     env:
       CI: "true"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Runs configurable code-quality checks (pre-commit, lint, deps, audit) via a matr
 jobs:
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@checks-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@workflow-checks-v1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       runner_small: self-hosted-hoprnet-small
@@ -68,7 +68,7 @@ Runs configurable test suites (unit, integration, nightly) and optionally builds
 jobs:
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@tests-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@workflow-tests-v1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       unit_tests: true
@@ -91,8 +91,8 @@ jobs:
 - `integration_test_command` (Optional): Command for integration tests (Default: `nix develop -c cargo nextest run --no-pager --test '*' -j 1`).
 - `nightly_test_command` (Optional): Command for nightly tests (Default: `nix build -L .#test-nightly`).
 - `benchmark_command` (Optional): Command for benchmarks (Default: `nix build .#bench-build`).
-- `unit_coverage_command` (Optional): Command for unit coverage.
-- `integration_coverage_command` (Optional): Command for integration coverage.
+- `unit_coverage_command` (Optional): Command for unit coverage (Default: `nix build -L .#coverage-unit && cp result coverage.lcov`).
+- `integration_coverage_command` (Optional): Command for integration coverage (Default: `nix develop .#coverage -c cargo llvm-cov nextest --no-pager ...`).
 - `runner` (Optional): Runner for all test jobs (Default: `ubuntu-latest`).
 - `test_timeout` (Optional): Timeout in minutes for test jobs (Default: `60`).
 - `benchmark_timeout` (Optional): Timeout in minutes for benchmark job (Default: `20`).
@@ -112,7 +112,7 @@ Scans GitHub Actions workflow files for security issues using [zizmor](https://d
 ```yaml
 jobs:
   zizmor:
-    uses: hoprnet/hopr-workflows/.github/workflows/checks-zizmor.yaml@checks-zizmor-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/checks-zizmor.yaml@workflow-checks-zizmor-v1
     permissions:
       contents: read
       security-events: write

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ jobs:
 - `benchmarks` (Optional): Enable benchmark builds on merge_group (Default: `false`).
 - `coverage` (Optional): Enable coverage reports (Default: `false`).
 - `unit_test_command` (Optional): Command for unit tests (Default: `nix build -L .#test-unit`).
-- `integration_test_command` (Optional): Command for integration tests (Default: `nix develop -c cargo nextest run --test '*' -j 1`).
+- `integration_test_command` (Optional): Command for integration tests (Default: `nix build -L .#test-integration`).
 - `nightly_test_command` (Optional): Command for nightly tests (Default: `nix build -L .#test-nightly`).
 - `benchmark_command` (Optional): Command for benchmarks (Default: `nix build .#bench-build`).
-- `unit_coverage_command` (Optional): Command for unit coverage (Default: `nix build -L .#coverage-unit && cp result coverage.lcov`).
-- `integration_coverage_command` (Optional): Command for integration coverage (Default: `nix develop .#coverage -c cargo llvm-cov nextest ...`).
+- `unit_coverage_command` (Optional): Command for unit coverage (Default: `nix run .#coverage-unit`).
+- `integration_coverage_command` (Optional): Command for integration coverage (Default: `nix run .#coverage-integration`).
 - `runner` (Optional): Runner for all test jobs (Default: `ubuntu-latest`).
 - `test_timeout` (Optional): Timeout in minutes for test jobs (Default: `60`).
 - `benchmark_timeout` (Optional): Timeout in minutes for benchmark job (Default: `20`).

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ jobs:
 - `benchmarks` (Optional): Enable benchmark builds on merge_group (Default: `false`).
 - `coverage` (Optional): Enable coverage reports (Default: `false`).
 - `unit_test_command` (Optional): Command for unit tests (Default: `nix build -L .#test-unit`).
-- `integration_test_command` (Optional): Command for integration tests (Default: `nix develop -c cargo nextest run --no-pager --test '*' -j 1`).
+- `integration_test_command` (Optional): Command for integration tests (Default: `nix develop -c cargo nextest run --test '*' -j 1`).
 - `nightly_test_command` (Optional): Command for nightly tests (Default: `nix build -L .#test-nightly`).
 - `benchmark_command` (Optional): Command for benchmarks (Default: `nix build .#bench-build`).
 - `unit_coverage_command` (Optional): Command for unit coverage (Default: `nix build -L .#coverage-unit && cp result coverage.lcov`).
-- `integration_coverage_command` (Optional): Command for integration coverage (Default: `nix develop .#coverage -c cargo llvm-cov nextest --no-pager ...`).
+- `integration_coverage_command` (Optional): Command for integration coverage (Default: `nix develop .#coverage -c cargo llvm-cov nextest ...`).
 - `runner` (Optional): Runner for all test jobs (Default: `ubuntu-latest`).
 - `test_timeout` (Optional): Timeout in minutes for test jobs (Default: `60`).
 - `benchmark_timeout` (Optional): Timeout in minutes for benchmark job (Default: `20`).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,116 @@ This repository contains a collection of custom GitHub Actions and Reusable Work
 
 This repository provides reusable workflows designed to simplify the build and release process for HOPR projects. These workflows can be called from other repositories to standardize binary compilation, Docker image creation, and multi-architecture support.
 
+### [Checks](./.github/workflows/checks.yaml)
+
+Runs configurable code-quality checks (pre-commit, lint, deps, audit) via a matrix strategy. Each check can be individually enabled/disabled and its command overridden.
+
+**Usage:**
+```yaml
+jobs:
+  checks:
+    name: Check
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@checks-v1
+    with:
+      source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
+      runner_small: self-hosted-hoprnet-small
+      runner_large: self-hosted-hoprnet-bigger
+    secrets:
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+```
+
+**Inputs:**
+- `source_branch` (Required): Source branch to check out.
+- `pre_commit` (Optional): Enable pre-commit check (Default: `true`).
+- `lint` (Optional): Enable lint check (Default: `true`).
+- `deps` (Optional): Enable dependency check (Default: `true`).
+- `audit` (Optional): Enable security audit (Default: `true`).
+- `pre_commit_command` (Optional): Command for pre-commit (Default: `nix build -L .#pre-commit-check`).
+- `lint_command` (Optional): Command for linting (Default: `nix run -L .#check`).
+- `deps_command` (Optional): Command for dependency check (Default: `nix develop .#ci -c bash -c "cargo machete && cargo shear"`).
+- `audit_command` (Optional): Command for security audit (Default: `nix run .#audit`).
+- `runner_small` (Optional): Runner for lightweight checks (Default: `ubuntu-latest`).
+- `runner_large` (Optional): Runner for heavy checks (Default: `ubuntu-latest`).
+
+**Secrets:**
+- `cachix_auth_token` (Required): Auth token for Cachix cache.
+
+---
+
+### [Tests](./.github/workflows/tests.yaml)
+
+Runs configurable test suites (unit, integration, nightly) and optionally builds benchmarks and generates coverage reports. Tests and benchmarks run concurrently; coverage runs after tests pass.
+
+**Usage:**
+```yaml
+jobs:
+  tests:
+    name: Test
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@tests-v1
+    with:
+      source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
+      unit_tests: true
+      integration_tests: true
+      coverage: true
+      runner: self-hosted-hoprnet-bigger
+    secrets:
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+```
+
+**Inputs:**
+- `source_branch` (Required): Source branch to check out.
+- `unit_tests` (Optional): Enable unit tests (Default: `true`).
+- `integration_tests` (Optional): Enable integration tests (Default: `false`).
+- `nightly_tests` (Optional): Enable nightly tests (Default: `false`).
+- `benchmarks` (Optional): Enable benchmark builds on merge_group (Default: `false`).
+- `coverage` (Optional): Enable coverage reports (Default: `false`).
+- `unit_test_command` (Optional): Command for unit tests (Default: `nix build -L .#test-unit`).
+- `integration_test_command` (Optional): Command for integration tests (Default: `nix develop -c cargo nextest run --no-pager --test '*' -j 1`).
+- `nightly_test_command` (Optional): Command for nightly tests (Default: `nix build -L .#test-nightly`).
+- `benchmark_command` (Optional): Command for benchmarks (Default: `nix build .#bench-build`).
+- `unit_coverage_command` (Optional): Command for unit coverage.
+- `integration_coverage_command` (Optional): Command for integration coverage.
+- `runner` (Optional): Runner for all test jobs (Default: `ubuntu-latest`).
+- `test_timeout` (Optional): Timeout in minutes for test jobs (Default: `60`).
+- `benchmark_timeout` (Optional): Timeout in minutes for benchmark job (Default: `20`).
+- `coverage_timeout` (Optional): Timeout in minutes for coverage jobs (Default: `60`).
+
+**Secrets:**
+- `cachix_auth_token` (Required): Auth token for Cachix cache.
+- `codecov_token` (Optional): Codecov token. Required when `coverage` is enabled.
+
+---
+
+### [Zizmor](./.github/workflows/checks-zizmor.yaml)
+
+Scans GitHub Actions workflow files for security issues using [zizmor](https://docs.zizmor.sh/) and uploads results as SARIF to the GitHub Security tab.
+
+**Usage:**
+```yaml
+jobs:
+  zizmor:
+    uses: hoprnet/hopr-workflows/.github/workflows/checks-zizmor.yaml@checks-zizmor-v1
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
+      runner: self-hosted-hoprnet-bigger
+    secrets:
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+```
+
+**Inputs:**
+- `source_branch` (Required): Source branch to check out.
+- `runner` (Optional): Runner for the job (Default: `ubuntu-latest`).
+- `zizmor_command` (Optional): Command to run zizmor (Default: `nix develop -L .#ci -c bash -c "zizmor --format sarif . > results.sarif"`).
+
+**Secrets:**
+- `cachix_auth_token` (Required): Auth token for Cachix cache.
+
+---
+
 ### [Build Binaries](./.github/workflows/build-binaries.yaml)
 
 Compiles binaries for a specific architecture using Nix. It handles version naming, signing and upload files to artifact registry.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ jobs:
 - `integration_test_command` (Optional): Command for integration tests (Default: `nix build -L .#test-integration`).
 - `nightly_test_command` (Optional): Command for nightly tests (Default: `nix build -L .#test-nightly`).
 - `benchmark_command` (Optional): Command for benchmarks (Default: `nix build .#bench-build`).
-- `unit_coverage_command` (Optional): Command for unit coverage (Default: `nix run .#coverage-unit`).
-- `integration_coverage_command` (Optional): Command for integration coverage (Default: `nix run .#coverage-integration`).
+- `unit_coverage_command` (Optional): Command for unit coverage (Default: `nix build -L .#coverage-unit && cp result coverage.lcov`).
+- `integration_coverage_command` (Optional): Command for integration coverage (Default: `nix build -L .#coverage-integration && cp result coverage.lcov`).
 - `runner` (Optional): Runner for all test jobs (Default: `ubuntu-latest`).
 - `test_timeout` (Optional): Timeout in minutes for test jobs (Default: `60`).
 - `benchmark_timeout` (Optional): Timeout in minutes for benchmark job (Default: `20`).

--- a/actions/nix-action/action.yaml
+++ b/actions/nix-action/action.yaml
@@ -32,7 +32,7 @@ runs:
   using: composite
   steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
       with:
         disable-sudo: ${{ inputs.disable_sudo }}
         egress-policy: audit


### PR DESCRIPTION
Add reusable `checks.yaml`, `tests.yaml`, and `checks-zizmor.yaml` workflows extracted from hoprnet PR #7989. All hoprnet org repos now call these instead of maintaining their own check/test sub-workflows.

Consumed by 12 repos (PRs linked in comments).

**After merge:** tag as `workflow-checks-v1`, `worflow-tests-v1`, `workflow-checks-zizmor-v1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three reusable CI workflows: Checks (pre-commit, lint, deps, audit), Tests (unit/integration/nightly, optional benchmarks, conditional coverage upload), and Zizmor security scan with SARIF upload.

* **Documentation**
  * Added usage examples and parameter/secret descriptions for the new reusable workflows.

* **Chores**
  * Upgraded runner hardening tooling to a newer pinned version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->