### PR TITLE
feat(ci): add reusable publish-crates workflow

### DIFF
--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -4,7 +4,7 @@
 #
 # Publishes a single Rust crate to crates.io using cargo-release in
 # publish-only mode (no git tags, no git push). Dry-run is the default;
-# set dry_run to false to actually publish.
+# set version_type to 'release' to actually publish.
 #
 # For workspace repos publishing multiple crates, use a matrix strategy
 # with max-parallel: 1 to control dependency ordering.
@@ -22,11 +22,11 @@ on:
         required: true
         type: string
         description: "Crate name to publish (e.g. hopr-types)"
-      dry_run:
+      version_type:
         required: false
-        type: boolean
-        default: true
-        description: "When true (default), simulates the publish without uploading"
+        type: string
+        default: "pr"
+        description: "Version type (commit, pr, release). Only 'release' publishes to crates.io; others perform a dry run"
       cachix_cache_name:
         required: false
         type: string
@@ -45,13 +45,13 @@ on:
         required: true
       cargo_registry_token:
         required: false
-        description: "crates.io API token (required when dry_run is false)"
+        description: "crates.io API token (required when version_type is 'release')"
 
 permissions: {}
 
 jobs:
   publish:
-    name: ${{ inputs.dry_run && 'Dry run' || 'Publish' }}
+    name: ${{ inputs.version_type == 'release' && 'Publish' || 'Dry run' }}
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     permissions:
@@ -77,11 +77,11 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}
           PACKAGE: ${{ inputs.package }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          VERSION_TYPE: ${{ inputs.version_type }}
         run: |
           set -euo pipefail
 
-          if [[ "$DRY_RUN" == "true" ]]; then
+          if [[ "$VERSION_TYPE" != "release" ]]; then
             echo "::group::cargo publish --dry-run -p $PACKAGE"
             nix develop -c cargo publish --dry-run -p "$PACKAGE"
             echo "::endgroup::"

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -18,15 +18,15 @@ on:
         required: true
         type: string
         description: "Source branch to check out"
-      package:
-        required: true
-        type: string
-        description: "Crate name to publish (e.g. hopr-types)"
       version_type:
         required: false
         type: string
         default: "pr"
         description: "Version type (commit, pr, release). Only 'release' publishes to crates.io; others perform a dry run"
+      package:
+        required: true
+        type: string
+        description: "Crate name to publish (e.g. hopr-types)"
       cachix_cache_name:
         required: false
         type: string
@@ -82,8 +82,9 @@ jobs:
           set -euo pipefail
 
           if [[ "$VERSION_TYPE" != "release" ]]; then
-            echo "::group::cargo publish --dry-run -p $PACKAGE"
-            nix develop -c cargo publish --dry-run -p "$PACKAGE"
+            echo "::group::cargo release publish -p $PACKAGE (dry-run)"
+            nix develop -c nix shell nixpkgs#cargo-release -c \
+              cargo release publish --package "$PACKAGE"
             echo "::endgroup::"
           else
             echo "::group::cargo release publish -p $PACKAGE --execute"

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -44,8 +44,8 @@ on:
       cachix_auth_token:
         required: true
       cargo_registry_token:
-        required: true
-        description: "crates.io API token"
+        required: false
+        description: "crates.io API token (required when dry_run is false)"
 
 permissions: {}
 

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -1,0 +1,91 @@
+---
+################################################################################
+# Reusable crate-publish pipeline
+#
+# Publishes a single Rust crate to crates.io using cargo-release in
+# publish-only mode (no git tags, no git push). Dry-run is the default;
+# set dry_run to false to actually publish.
+#
+# For workspace repos publishing multiple crates, use a matrix strategy
+# with max-parallel: 1 to control dependency ordering.
+################################################################################
+name: Publish crates
+
+on:
+  workflow_call:
+    inputs:
+      source_branch:
+        required: true
+        type: string
+        description: "Source branch to check out"
+      package:
+        required: true
+        type: string
+        description: "Crate name to publish (e.g. hopr-types)"
+      dry_run:
+        required: false
+        type: boolean
+        default: true
+        description: "When true (default), simulates the publish without uploading"
+      cachix_cache_name:
+        required: false
+        type: string
+        description: "Cachix cache name to use"
+      runner:
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout_minutes:
+        required: false
+        type: number
+        default: 30
+        description: "Timeout for the job in minutes"
+    secrets:
+      cachix_auth_token:
+        required: true
+      cargo_registry_token:
+        required: true
+        description: "crates.io API token"
+
+permissions: {}
+
+jobs:
+  publish:
+    name: ${{ inputs.dry_run && 'Dry run' || 'Publish' }}
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.source_branch }}
+      - name: Setup Nix
+        uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
+        with:
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
+          cachix_auth_token: ${{ secrets.cachix_auth_token }}
+      - name: Publish crate
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}
+          PACKAGE: ${{ inputs.package }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          args=(cargo release publish --no-tag --no-push --package "$PACKAGE")
+          if [[ "$DRY_RUN" != "true" ]]; then
+            args+=(--execute)
+          fi
+
+          echo "::group::cargo-release ${args[*]:2}"
+          nix develop -c nix shell nixpkgs#cargo-release -c "${args[@]}"
+          echo "::endgroup::"

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -81,7 +81,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          args=(cargo release publish --no-tag --no-push --package "$PACKAGE")
+          args=(cargo release publish --package "$PACKAGE")
           if [[ "$DRY_RUN" != "true" ]]; then
             args+=(--execute)
           fi

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -81,11 +81,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          args=(cargo release publish --package "$PACKAGE")
-          if [[ "$DRY_RUN" != "true" ]]; then
-            args+=(--execute)
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "::group::cargo publish --dry-run -p $PACKAGE"
+            nix develop -c cargo publish --dry-run -p "$PACKAGE"
+            echo "::endgroup::"
+          else
+            echo "::group::cargo release publish -p $PACKAGE --execute"
+            nix develop -c nix shell nixpkgs#cargo-release -c \
+              cargo release publish --package "$PACKAGE" --execute
+            echo "::endgroup::"
           fi
-
-          echo "::group::cargo-release ${args[*]:2}"
-          nix develop -c nix shell nixpkgs#cargo-release -c "${args[@]}"
-          echo "::endgroup::"

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -81,6 +81,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [[ "$VERSION_TYPE" == "release" && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+            echo "::error::secrets.cargo_registry_token is required when version_type='release'"
+            exit 1
+          fi
+
           if [[ "$VERSION_TYPE" != "release" ]]; then
             echo "::group::cargo release publish -p $PACKAGE (dry-run)"
             nix develop -c nix shell nixpkgs#cargo-release -c \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository contains a collection of custom GitHub Actions and Reusable Work
 
 ## Reusable Workflows
 
-This repository provides reusable workflows designed to simplify the build and release process for HOPR projects. These workflows can be called from other repositories to standardize binary compilation, Docker image creation, and multi-architecture support.
+This repository provides reusable workflows designed to simplify the build and release process for HOPR projects. These workflows can be called from other repositories to standardize binary compilation, Docker image creation, multi-architecture support, and crate publishing.
 
 ### [Checks](./.github/workflows/checks.yaml)
 


### PR DESCRIPTION
## Summary

- Add reusable `publish-crates.yaml` workflow for publishing Rust crates to crates.io
- Uses `version_type` string input (`commit`, `pr`, `release`) to control publish behavior
- Only `version_type: release` triggers actual publishing; all other values perform a dry run (safe-by-default)
- Uses `cargo-release` for both dry-run and actual publishing (with `--execute` flag for real publishes)
- Fails fast with actionable error when `cargo_registry_token` is missing on release