### PR TITLE
feat(ci): add unit_coverage and integration_coverage inputs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,8 +5,8 @@
 # Tests and benchmarks run concurrently.
 # Coverage runs after all tests pass, unless `unconditional` is set.
 #
-# When `coverage` is enabled, the `codecov_token` secret must be provided
-# for the upload to succeed.
+# When `unit_coverage` or `integration_coverage` is enabled, the
+# `codecov_token` secret must be provided for the upload to succeed.
 ################################################################################
 name: Tests
 
@@ -32,20 +32,16 @@ on:
         required: false
         type: boolean
         default: false
-      coverage:
-        required: false
-        type: boolean
-        default: false
       unit_coverage:
         required: false
         type: boolean
         default: false
-        description: Run unit coverage when coverage is enabled.
+        description: Enable unit coverage report generation and upload.
       integration_coverage:
         required: false
         type: boolean
         default: false
-        description: Run integration coverage when coverage is enabled.
+        description: Enable integration coverage report generation and upload.
       unit_test_command:
         required: false
         type: string
@@ -162,7 +158,7 @@ jobs:
       contents: read
     if: >-
       always() &&
-      inputs.coverage &&
+      (inputs.unit_coverage || inputs.integration_coverage) &&
       (inputs.unconditional || needs.test.result == 'success') &&
       (
         github.event_name == 'push' ||

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ on:
       unit_coverage:
         required: false
         type: boolean
-        default: true
+        default: false
         description: Run unit coverage when coverage is enabled.
       integration_coverage:
         required: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,16 @@ on:
         required: false
         type: boolean
         default: false
+      unit_coverage:
+        required: false
+        type: boolean
+        default: true
+        description: Run unit coverage when coverage is enabled.
+      integration_coverage:
+        required: false
+        type: boolean
+        default: false
+        description: Run integration coverage when coverage is enabled.
       unit_test_command:
         required: false
         type: string
@@ -81,8 +91,8 @@ on:
         type: boolean
         default: false
         description: >-
-          When true, coverage runs regardless of test results and is enabled
-          for all coverage types even if their corresponding test flags are off.
+          When true, coverage runs regardless of test results.
+          Use unit_coverage and integration_coverage to control which types run.
     secrets:
       cachix_auth_token:
         required: true
@@ -166,11 +176,11 @@ jobs:
       matrix:
         include:
           - name: Unit
-            enabled: ${{ inputs.unconditional || inputs.unit_tests }}
+            enabled: ${{ inputs.unit_coverage }}
             command: ${{ inputs.unit_coverage_command }}
             flag: unit
           - name: Integration
-            enabled: ${{ inputs.unconditional || inputs.integration_tests }}
+            enabled: ${{ inputs.integration_coverage }}
             command: ${{ inputs.integration_coverage_command }}
             flag: integration
     steps:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ jobs:
 - `nightly_tests` (Optional): Enable nightly tests (Default: `false`).
 - `benchmarks` (Optional): Enable benchmark builds on merge_group (Default: `false`).
 - `coverage` (Optional): Enable coverage reports (Default: `false`).
-- `unit_coverage` (Optional): Run unit coverage when coverage is enabled (Default: `true`).
+- `unit_coverage` (Optional): Run unit coverage when coverage is enabled (Default: `false`).
 - `integration_coverage` (Optional): Run integration coverage when coverage is enabled (Default: `false`).
 - `unit_test_command` (Optional): Command for unit tests (Default: `nix build -L .#test-unit`).
 - `integration_test_command` (Optional): Command for integration tests (Default: `nix build -L .#test-integration`).

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ jobs:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       unit_tests: true
       integration_tests: true
-      coverage: true
+      unit_coverage: true
+      integration_coverage: true
       runner: self-hosted-hoprnet-bigger
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -86,9 +87,8 @@ jobs:
 - `integration_tests` (Optional): Enable integration tests (Default: `false`).
 - `nightly_tests` (Optional): Enable nightly tests (Default: `false`).
 - `benchmarks` (Optional): Enable benchmark builds on merge_group (Default: `false`).
-- `coverage` (Optional): Enable coverage reports (Default: `false`).
-- `unit_coverage` (Optional): Run unit coverage when coverage is enabled (Default: `false`).
-- `integration_coverage` (Optional): Run integration coverage when coverage is enabled (Default: `false`).
+- `unit_coverage` (Optional): Enable unit coverage report (Default: `false`).
+- `integration_coverage` (Optional): Enable integration coverage report (Default: `false`).
 - `unit_test_command` (Optional): Command for unit tests (Default: `nix build -L .#test-unit`).
 - `integration_test_command` (Optional): Command for integration tests (Default: `nix build -L .#test-integration`).
 - `nightly_test_command` (Optional): Command for nightly tests (Default: `nix build -L .#test-nightly`).
@@ -103,7 +103,7 @@ jobs:
 
 **Secrets:**
 - `cachix_auth_token` (Required): Auth token for Cachix cache.
-- `codecov_token` (Optional): Codecov token. Required when `coverage` is enabled.
+- `codecov_token` (Optional): Codecov token. Required when `unit_coverage` or `integration_coverage` is enabled.
 
 **Coverage-only usage (e.g. post-merge pipeline):**
 ```yaml
@@ -115,7 +115,6 @@ jobs:
       source_branch: ${{ github.ref_name }}
       unit_tests: false
       integration_tests: false
-      coverage: true
       unconditional: true
       unit_coverage: true
       runner: self-hosted-hoprnet-bigger

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ jobs:
 - `nightly_tests` (Optional): Enable nightly tests (Default: `false`).
 - `benchmarks` (Optional): Enable benchmark builds on merge_group (Default: `false`).
 - `coverage` (Optional): Enable coverage reports (Default: `false`).
+- `unit_coverage` (Optional): Run unit coverage when coverage is enabled (Default: `true`).
+- `integration_coverage` (Optional): Run integration coverage when coverage is enabled (Default: `false`).
 - `unit_test_command` (Optional): Command for unit tests (Default: `nix build -L .#test-unit`).
 - `integration_test_command` (Optional): Command for integration tests (Default: `nix build -L .#test-integration`).
 - `nightly_test_command` (Optional): Command for nightly tests (Default: `nix build -L .#test-nightly`).
@@ -97,7 +99,7 @@ jobs:
 - `test_timeout` (Optional): Timeout in minutes for test jobs (Default: `60`).
 - `benchmark_timeout` (Optional): Timeout in minutes for benchmark job (Default: `20`).
 - `coverage_timeout` (Optional): Timeout in minutes for coverage jobs (Default: `60`).
-- `unconditional` (Optional): When `true`, coverage runs regardless of test results and is enabled for all coverage types even if their corresponding test flags are off (Default: `false`).
+- `unconditional` (Optional): When `true`, coverage runs regardless of test results. Use `unit_coverage` and `integration_coverage` to control which types run (Default: `false`).
 
 **Secrets:**
 - `cachix_auth_token` (Required): Auth token for Cachix cache.
@@ -115,6 +117,7 @@ jobs:
       integration_tests: false
       coverage: true
       unconditional: true
+      unit_coverage: true
       runner: self-hosted-hoprnet-bigger
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `unit_coverage` and `integration_coverage` boolean inputs (both default `false`) to independently control which coverage types run
- Remove the `coverage` input — redundant now that each type has its own toggle
- `unconditional` now only controls whether coverage waits for tests to pass, not which types run
- Coverage job `if` uses `(inputs.unit_coverage || inputs.integration_coverage)` instead of `inputs.coverage`
- Eliminates the `integration_coverage_command: "touch coverage.lcov"` workaround for repos without integration tests