### PR TITLE
feat(tests): add runner_integration input for per-job runner selection

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -155,7 +155,7 @@ jobs:
   # ── Benchmark ──────────────────────────────────────────────────────────────
   benchmark:
     name: Benchmark
-    if: inputs.enable_benchmarks
+    if: inputs.enable_benchmarks && github.event_name == 'merge_group'
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.benchmark_timeout }}
     permissions:
@@ -175,7 +175,7 @@ jobs:
     if: >-
       always() &&
       inputs.enable_unit_coverage &&
-      (needs.unit-test.result == 'success' || needs.unit-test.result == 'skipped') &&
+      (needs['unit-test'].result == 'success' || needs['unit-test'].result == 'skipped') &&
       (
         github.event_name == 'push' ||
         github.event_name == 'merge_group' ||
@@ -198,7 +198,7 @@ jobs:
       - name: Upload Unit report
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         if: >-
-          github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+          github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           files: coverage.lcov
           flags: unit
@@ -211,7 +211,7 @@ jobs:
     if: >-
       always() &&
       inputs.enable_integration_coverage &&
-      (needs.integration-test.result == 'success' || needs.integration-test.result == 'skipped') &&
+      (needs['integration-test'].result == 'success' || needs['integration-test'].result == 'skipped') &&
       (
         github.event_name == 'push' ||
         github.event_name == 'merge_group' ||
@@ -234,7 +234,7 @@ jobs:
       - name: Upload Integration report
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         if: >-
-          github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+          github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           files: coverage.lcov
           flags: integration

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,11 +2,10 @@
 ################################################################################
 # Reusable test + coverage pipeline
 #
-# Tests and benchmarks run concurrently.
-# Coverage runs after all tests pass, unless `unconditional` is set.
-#
-# When `unit_coverage` or `integration_coverage` is enabled, the
-# `codecov_token` secret must be provided for the upload to succeed.
+# Each job is individually conditional via `enable_*` inputs.
+# Coverage runs after the corresponding test passes, or if the test was
+# disabled (skipped). Coverage is gated to non-draft PRs, push, and
+# merge_group events.
 ################################################################################
 name: Tests
 
@@ -16,28 +15,28 @@ on:
       source_branch:
         required: true
         type: string
-      unit_tests:
+      enable_unit_tests:
         required: false
         type: boolean
         default: true
-      integration_tests:
+      enable_integration_tests:
         required: false
         type: boolean
         default: false
-      nightly_tests:
+      enable_nightly_tests:
         required: false
         type: boolean
         default: false
-      benchmarks:
+      enable_benchmarks:
         required: false
         type: boolean
         default: false
-      unit_coverage:
+      enable_unit_coverage:
         required: false
         type: boolean
         default: false
         description: Enable unit coverage report generation and upload.
-      integration_coverage:
+      enable_integration_coverage:
         required: false
         type: boolean
         default: false
@@ -88,13 +87,6 @@ on:
         required: false
         type: number
         default: 60
-      unconditional:
-        required: false
-        type: boolean
-        default: false
-        description: >-
-          When true, coverage runs regardless of test results.
-          Use unit_coverage and integration_coverage to control which types run.
     secrets:
       cachix_auth_token:
         required: true
@@ -108,103 +100,143 @@ env:
   FOUNDRY_PROFILE: ci
 
 jobs:
-  # ── Tests + Benchmarks (concurrent) ────────────────────────────────────────
-  test:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
+  # ── Tests ──────────────────────────────────────────────────────────────────
+  unit-test:
+    name: Unit
+    if: inputs.enable_unit_tests
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.test_timeout }}
     permissions:
       contents: read
     env:
       CI: "true"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Unit
-            enabled: ${{ inputs.unit_tests }}
-            command: ${{ inputs.unit_test_command }}
-            runner: ${{ inputs.runner }}
-          - name: Integration
-            enabled: ${{ inputs.integration_tests }}
-            command: ${{ inputs.integration_test_command }}
-            runner: ${{ inputs.runner_integration || inputs.runner }}
-          - name: Unit Nightly
-            enabled: ${{ inputs.nightly_tests }}
-            command: ${{ inputs.nightly_test_command }}
-            runner: ${{ inputs.runner }}
     steps:
-      - name: Run ${{ matrix.name }}
-        if: matrix.enabled
+      - name: Run Unit
         uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
         with:
           source_branch: ${{ inputs.source_branch }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
-          command: ${{ matrix.command }}
+          command: ${{ inputs.unit_test_command }}
 
-  build-benchmarks:
+  integration-test:
+    name: Integration
+    if: inputs.enable_integration_tests
+    runs-on: ${{ inputs.runner_integration || inputs.runner }}
+    timeout-minutes: ${{ inputs.test_timeout }}
+    permissions:
+      contents: read
+    env:
+      CI: "true"
+    steps:
+      - name: Run Integration
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
+        with:
+          source_branch: ${{ inputs.source_branch }}
+          cachix_auth_token: ${{ secrets.cachix_auth_token }}
+          command: ${{ inputs.integration_test_command }}
+
+  nightly-test:
+    name: Unit Nightly
+    if: inputs.enable_nightly_tests
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.test_timeout }}
+    permissions:
+      contents: read
+    env:
+      CI: "true"
+    steps:
+      - name: Run Unit Nightly
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
+        with:
+          source_branch: ${{ inputs.source_branch }}
+          cachix_auth_token: ${{ secrets.cachix_auth_token }}
+          command: ${{ inputs.nightly_test_command }}
+
+  # ── Benchmark ──────────────────────────────────────────────────────────────
+  benchmark:
     name: Benchmark
+    if: inputs.enable_benchmarks
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.benchmark_timeout }}
     permissions:
       contents: read
-    if: inputs.benchmarks && github.event_name == 'merge_group'
     steps:
-      - name: Build benchmarks
+      - name: Run Benchmark
         uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
         with:
           source_branch: ${{ inputs.source_branch }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
           command: ${{ inputs.benchmark_command }}
 
-  # ── Coverage (after tests pass, unless unconditional) ──────────────────────
-  coverage:
-    name: Coverage / ${{ matrix.name }}
-    needs: [test]
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ inputs.coverage_timeout }}
-    permissions:
-      contents: read
+  # ── Coverage ───────────────────────────────────────────────────────────────
+  unit-coverage:
+    name: Coverage / Unit
+    needs: [unit-test]
     if: >-
       always() &&
-      (inputs.unit_coverage || inputs.integration_coverage) &&
-      (inputs.unconditional || needs.test.result == 'success') &&
+      inputs.enable_unit_coverage &&
+      (needs.unit-test.result == 'success' || needs.unit-test.result == 'skipped') &&
       (
         github.event_name == 'push' ||
         github.event_name == 'merge_group' ||
         (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
       )
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.coverage_timeout }}
+    permissions:
+      contents: read
     env:
       CI: "true"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Unit
-            enabled: ${{ inputs.unit_coverage }}
-            command: ${{ inputs.unit_coverage_command }}
-            flag: unit
-            runner: ${{ inputs.runner }}
-          - name: Integration
-            enabled: ${{ inputs.integration_coverage }}
-            command: ${{ inputs.integration_coverage_command }}
-            flag: integration
-            runner: ${{ inputs.runner_integration || inputs.runner }}
     steps:
-      - name: Generate ${{ matrix.name }} report
-        if: matrix.enabled
+      - name: Generate Unit report
         uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
         with:
           source_branch: ${{ inputs.source_branch }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
-          command: ${{ matrix.command }}
+          command: ${{ inputs.unit_coverage_command }}
 
-      - name: Upload ${{ matrix.name }} report
+      - name: Upload Unit report
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         if: >-
-          matrix.enabled && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+          github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           files: coverage.lcov
-          flags: ${{ matrix.flag }}
+          flags: unit
+          fail_ci_if_error: true
+          token: ${{ secrets.codecov_token }}
+
+  integration-coverage:
+    name: Coverage / Integration
+    needs: [integration-test]
+    if: >-
+      always() &&
+      inputs.enable_integration_coverage &&
+      (needs.integration-test.result == 'success' || needs.integration-test.result == 'skipped') &&
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
+        (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+      )
+    runs-on: ${{ inputs.runner_integration || inputs.runner }}
+    timeout-minutes: ${{ inputs.coverage_timeout }}
+    permissions:
+      contents: read
+    env:
+      CI: "true"
+    steps:
+      - name: Generate Integration report
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
+        with:
+          source_branch: ${{ inputs.source_branch }}
+          cachix_auth_token: ${{ secrets.cachix_auth_token }}
+          command: ${{ inputs.integration_coverage_command }}
+
+      - name: Upload Integration report
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        if: >-
+          github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          files: coverage.lcov
+          flags: integration
           fail_ci_if_error: true
           token: ${{ secrets.codecov_token }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -70,6 +70,12 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
+      runner_integration:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Runner for integration tests and coverage. Falls back to `runner` if empty.
       test_timeout:
         required: false
         type: number
@@ -105,7 +111,7 @@ jobs:
   # ── Tests + Benchmarks (concurrent) ────────────────────────────────────────
   test:
     name: ${{ matrix.name }}
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ inputs.test_timeout }}
     permissions:
       contents: read
@@ -118,12 +124,15 @@ jobs:
           - name: Unit
             enabled: ${{ inputs.unit_tests }}
             command: ${{ inputs.unit_test_command }}
+            runner: ${{ inputs.runner }}
           - name: Integration
             enabled: ${{ inputs.integration_tests }}
             command: ${{ inputs.integration_test_command }}
+            runner: ${{ inputs.runner_integration || inputs.runner }}
           - name: Unit Nightly
             enabled: ${{ inputs.nightly_tests }}
             command: ${{ inputs.nightly_test_command }}
+            runner: ${{ inputs.runner }}
     steps:
       - name: Run ${{ matrix.name }}
         if: matrix.enabled
@@ -152,7 +161,7 @@ jobs:
   coverage:
     name: Coverage / ${{ matrix.name }}
     needs: [test]
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ inputs.coverage_timeout }}
     permissions:
       contents: read
@@ -175,10 +184,12 @@ jobs:
             enabled: ${{ inputs.unit_coverage }}
             command: ${{ inputs.unit_coverage_command }}
             flag: unit
+            runner: ${{ inputs.runner }}
           - name: Integration
             enabled: ${{ inputs.integration_coverage }}
             command: ${{ inputs.integration_coverage_command }}
             flag: integration
+            runner: ${{ inputs.runner_integration || inputs.runner }}
     steps:
       - name: Generate ${{ matrix.name }} report
         if: matrix.enabled

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -155,7 +155,7 @@ jobs:
   # ── Benchmark ──────────────────────────────────────────────────────────────
   benchmark:
     name: Benchmark
-    if: inputs.enable_benchmarks && github.event_name == 'merge_group'
+    if: inputs.enable_benchmarks
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.benchmark_timeout }}
     permissions:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,8 +5,8 @@
 # Tests and benchmarks run concurrently.
 # Coverage runs after all tests pass, unless `unconditional` is set.
 #
-# When `coverage` is enabled, the `codecov_token` secret must be provided
-# for the upload to succeed.
+# When `unit_coverage` or `integration_coverage` is enabled, the
+# `codecov_token` secret must be provided for the upload to succeed.
 ################################################################################
 name: Tests
 
@@ -32,20 +32,16 @@ on:
         required: false
         type: boolean
         default: false
-      coverage:
-        required: false
-        type: boolean
-        default: false
       unit_coverage:
         required: false
         type: boolean
         default: false
-        description: Run unit coverage when coverage is enabled.
+        description: Enable unit coverage report generation and upload.
       integration_coverage:
         required: false
         type: boolean
         default: false
-        description: Run integration coverage when coverage is enabled.
+        description: Enable integration coverage report generation and upload.
       unit_test_command:
         required: false
         type: string
@@ -162,7 +158,7 @@ jobs:
       contents: read
     if: >-
       always() &&
-      inputs.coverage &&
+      (inputs.unit_coverage || inputs.integration_coverage) &&
       (inputs.unconditional || needs.test.result == 'success') &&
       (
         github.event_name == 'push' ||

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,16 +65,18 @@ on:
         required: false
         type: string
         default: "nix run .#coverage-integration"
-      runner:
+      runner_unit:
         required: false
         type: string
         default: "ubuntu-latest"
+        description: >-
+          Runner for unit tests, nightly tests, benchmarks, and unit coverage.
       runner_integration:
         required: false
         type: string
         default: ""
         description: >-
-          Runner for integration tests and coverage. Falls back to `runner` if empty.
+          Runner for integration tests and coverage. Falls back to `runner_unit` if empty.
       test_timeout:
         required: false
         type: number
@@ -104,7 +106,7 @@ jobs:
   unit-test:
     name: Unit
     if: inputs.enable_unit_tests
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner_unit }}
     timeout-minutes: ${{ inputs.test_timeout }}
     permissions:
       contents: read
@@ -121,7 +123,7 @@ jobs:
   integration-test:
     name: Integration
     if: inputs.enable_integration_tests
-    runs-on: ${{ inputs.runner_integration || inputs.runner }}
+    runs-on: ${{ inputs.runner_integration || inputs.runner_unit }}
     timeout-minutes: ${{ inputs.test_timeout }}
     permissions:
       contents: read
@@ -138,7 +140,7 @@ jobs:
   nightly-test:
     name: Unit Nightly
     if: inputs.enable_nightly_tests
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner_unit }}
     timeout-minutes: ${{ inputs.test_timeout }}
     permissions:
       contents: read
@@ -156,7 +158,7 @@ jobs:
   benchmark:
     name: Benchmark
     if: inputs.enable_benchmarks
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner_unit }}
     timeout-minutes: ${{ inputs.benchmark_timeout }}
     permissions:
       contents: read
@@ -181,7 +183,7 @@ jobs:
         github.event_name == 'merge_group' ||
         (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
       )
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner_unit }}
     timeout-minutes: ${{ inputs.coverage_timeout }}
     permissions:
       contents: read
@@ -217,7 +219,7 @@ jobs:
         github.event_name == 'merge_group' ||
         (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
       )
-    runs-on: ${{ inputs.runner_integration || inputs.runner }}
+    runs-on: ${{ inputs.runner_integration || inputs.runner_unit }}
     timeout-minutes: ${{ inputs.coverage_timeout }}
     permissions:
       contents: read

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ on:
       unit_coverage:
         required: false
         type: boolean
-        default: true
+        default: false
         description: Run unit coverage when coverage is enabled.
       integration_coverage:
         required: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,16 @@ on:
         required: false
         type: boolean
         default: false
+      unit_coverage:
+        required: false
+        type: boolean
+        default: true
+        description: Run unit coverage when coverage is enabled.
+      integration_coverage:
+        required: false
+        type: boolean
+        default: false
+        description: Run integration coverage when coverage is enabled.
       unit_test_command:
         required: false
         type: string
@@ -81,8 +91,8 @@ on:
         type: boolean
         default: false
         description: >-
-          When true, coverage runs regardless of test results and is enabled
-          for all coverage types even if their corresponding test flags are off.
+          When true, coverage runs regardless of test results.
+          Use unit_coverage and integration_coverage to control which types run.
     secrets:
       cachix_auth_token:
         required: true
@@ -166,11 +176,11 @@ jobs:
       matrix:
         include:
           - name: Unit
-            enabled: ${{ inputs.unconditional || inputs.unit_tests }}
+            enabled: ${{ inputs.unit_coverage }}
             command: ${{ inputs.unit_coverage_command }}
             flag: unit
           - name: Integration
-            enabled: ${{ inputs.unconditional || inputs.integration_tests }}
+            enabled: ${{ inputs.integration_coverage }}
             command: ${{ inputs.integration_coverage_command }}
             flag: integration
     steps:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ jobs:
 - `nightly_tests` (Optional): Enable nightly tests (Default: `false`).
 - `benchmarks` (Optional): Enable benchmark builds on merge_group (Default: `false`).
 - `coverage` (Optional): Enable coverage reports (Default: `false`).
-- `unit_coverage` (Optional): Run unit coverage when coverage is enabled (Default: `true`).
+- `unit_coverage` (Optional): Run unit coverage when coverage is enabled (Default: `false`).
 - `integration_coverage` (Optional): Run integration coverage when coverage is enabled (Default: `false`).
 - `unit_test_command` (Optional): Command for unit tests (Default: `nix build -L .#test-unit`).
 - `integration_test_command` (Optional): Command for integration tests (Default: `nix build -L .#test-integration`).

--- a/README.md
+++ b/README.md
@@ -61,21 +61,22 @@ jobs:
 
 ### [Tests](./.github/workflows/tests.yaml)
 
-Runs configurable test suites (unit, integration, nightly) and optionally builds benchmarks and generates coverage reports. Tests and benchmarks run concurrently; coverage runs after tests pass. Set `unconditional: true` to run coverage regardless of test results.
+Runs configurable test suites (unit, integration, nightly), benchmarks, and coverage reports as individual conditional jobs. Each coverage job depends only on its corresponding test — it runs when the test passes or when the test is disabled (skipped).
 
 **Usage:**
 ```yaml
 jobs:
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@workflow-tests-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@workflow-tests-v4
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      unit_tests: true
-      integration_tests: true
-      unit_coverage: true
-      integration_coverage: true
-      runner: self-hosted-hoprnet-bigger
+      enable_unit_tests: true
+      enable_integration_tests: true
+      enable_unit_coverage: true
+      enable_integration_coverage: true
+      runner: depot-ubuntu-24.04-16
+      runner_integration: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
@@ -83,41 +84,42 @@ jobs:
 
 **Inputs:**
 - `source_branch` (Required): Source branch to check out.
-- `unit_tests` (Optional): Enable unit tests (Default: `true`).
-- `integration_tests` (Optional): Enable integration tests (Default: `false`).
-- `nightly_tests` (Optional): Enable nightly tests (Default: `false`).
-- `benchmarks` (Optional): Enable benchmark builds on merge_group (Default: `false`).
-- `unit_coverage` (Optional): Enable unit coverage report (Default: `false`).
-- `integration_coverage` (Optional): Enable integration coverage report (Default: `false`).
+- `enable_unit_tests` (Optional): Enable unit tests (Default: `true`).
+- `enable_integration_tests` (Optional): Enable integration tests (Default: `false`).
+- `enable_nightly_tests` (Optional): Enable nightly tests (Default: `false`).
+- `enable_benchmarks` (Optional): Enable benchmarks (Default: `false`).
+- `enable_unit_coverage` (Optional): Enable unit coverage report (Default: `false`).
+- `enable_integration_coverage` (Optional): Enable integration coverage report (Default: `false`).
 - `unit_test_command` (Optional): Command for unit tests (Default: `nix build -L .#test-unit`).
 - `integration_test_command` (Optional): Command for integration tests (Default: `nix build -L .#test-integration`).
 - `nightly_test_command` (Optional): Command for nightly tests (Default: `nix build -L .#test-nightly`).
 - `benchmark_command` (Optional): Command for benchmarks (Default: `nix build .#bench-build`).
-- `unit_coverage_command` (Optional): Command for unit coverage (Default: `nix build -L .#coverage-unit && cp result coverage.lcov`).
-- `integration_coverage_command` (Optional): Command for integration coverage (Default: `nix build -L .#coverage-integration && cp result coverage.lcov`).
-- `runner` (Optional): Runner for all test jobs (Default: `ubuntu-latest`).
+- `unit_coverage_command` (Optional): Command for unit coverage (Default: `nix run .#coverage-unit`).
+- `integration_coverage_command` (Optional): Command for integration coverage (Default: `nix run .#coverage-integration`).
+- `runner` (Optional): Runner for unit tests, nightly tests, benchmarks, and unit coverage (Default: `ubuntu-latest`).
+- `runner_integration` (Optional): Runner for integration tests and integration coverage. Falls back to `runner` if empty (Default: `""`).
 - `test_timeout` (Optional): Timeout in minutes for test jobs (Default: `60`).
 - `benchmark_timeout` (Optional): Timeout in minutes for benchmark job (Default: `20`).
 - `coverage_timeout` (Optional): Timeout in minutes for coverage jobs (Default: `60`).
-- `unconditional` (Optional): When `true`, coverage runs regardless of test results. Use `unit_coverage` and `integration_coverage` to control which types run (Default: `false`).
 
 **Secrets:**
 - `cachix_auth_token` (Required): Auth token for Cachix cache.
-- `codecov_token` (Optional): Codecov token. Required when `unit_coverage` or `integration_coverage` is enabled.
+- `codecov_token` (Optional): Codecov token. Required when `enable_unit_coverage` or `enable_integration_coverage` is enabled.
 
 **Coverage-only usage (e.g. post-merge pipeline):**
 ```yaml
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@workflow-tests-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@workflow-tests-v4
     with:
       source_branch: ${{ github.ref_name }}
-      unit_tests: false
-      integration_tests: false
-      unconditional: true
-      unit_coverage: true
-      runner: self-hosted-hoprnet-bigger
+      enable_unit_tests: false
+      enable_integration_tests: false
+      enable_unit_coverage: true
+      enable_integration_coverage: true
+      runner: depot-ubuntu-24.04-16
+      runner_integration: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ jobs:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       unit_tests: true
       integration_tests: true
-      coverage: true
+      unit_coverage: true
+      integration_coverage: true
       runner: self-hosted-hoprnet-bigger
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -86,9 +87,8 @@ jobs:
 - `integration_tests` (Optional): Enable integration tests (Default: `false`).
 - `nightly_tests` (Optional): Enable nightly tests (Default: `false`).
 - `benchmarks` (Optional): Enable benchmark builds on merge_group (Default: `false`).
-- `coverage` (Optional): Enable coverage reports (Default: `false`).
-- `unit_coverage` (Optional): Run unit coverage when coverage is enabled (Default: `false`).
-- `integration_coverage` (Optional): Run integration coverage when coverage is enabled (Default: `false`).
+- `unit_coverage` (Optional): Enable unit coverage report (Default: `false`).
+- `integration_coverage` (Optional): Enable integration coverage report (Default: `false`).
 - `unit_test_command` (Optional): Command for unit tests (Default: `nix build -L .#test-unit`).
 - `integration_test_command` (Optional): Command for integration tests (Default: `nix build -L .#test-integration`).
 - `nightly_test_command` (Optional): Command for nightly tests (Default: `nix build -L .#test-nightly`).
@@ -103,7 +103,7 @@ jobs:
 
 **Secrets:**
 - `cachix_auth_token` (Required): Auth token for Cachix cache.
-- `codecov_token` (Optional): Codecov token. Required when `coverage` is enabled.
+- `codecov_token` (Optional): Codecov token. Required when `unit_coverage` or `integration_coverage` is enabled.
 
 **Coverage-only usage (e.g. post-merge pipeline):**
 ```yaml
@@ -115,7 +115,6 @@ jobs:
       source_branch: ${{ github.ref_name }}
       unit_tests: false
       integration_tests: false
-      coverage: true
       unconditional: true
       unit_coverage: true
       runner: self-hosted-hoprnet-bigger

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ jobs:
 - `nightly_tests` (Optional): Enable nightly tests (Default: `false`).
 - `benchmarks` (Optional): Enable benchmark builds on merge_group (Default: `false`).
 - `coverage` (Optional): Enable coverage reports (Default: `false`).
+- `unit_coverage` (Optional): Run unit coverage when coverage is enabled (Default: `true`).
+- `integration_coverage` (Optional): Run integration coverage when coverage is enabled (Default: `false`).
 - `unit_test_command` (Optional): Command for unit tests (Default: `nix build -L .#test-unit`).
 - `integration_test_command` (Optional): Command for integration tests (Default: `nix build -L .#test-integration`).
 - `nightly_test_command` (Optional): Command for nightly tests (Default: `nix build -L .#test-nightly`).
@@ -97,7 +99,7 @@ jobs:
 - `test_timeout` (Optional): Timeout in minutes for test jobs (Default: `60`).
 - `benchmark_timeout` (Optional): Timeout in minutes for benchmark job (Default: `20`).
 - `coverage_timeout` (Optional): Timeout in minutes for coverage jobs (Default: `60`).
-- `unconditional` (Optional): When `true`, coverage runs regardless of test results and is enabled for all coverage types even if their corresponding test flags are off (Default: `false`).
+- `unconditional` (Optional): When `true`, coverage runs regardless of test results. Use `unit_coverage` and `integration_coverage` to control which types run (Default: `false`).
 
 **Secrets:**
 - `cachix_auth_token` (Required): Auth token for Cachix cache.
@@ -115,6 +117,7 @@ jobs:
       integration_tests: false
       coverage: true
       unconditional: true
+      unit_coverage: true
       runner: self-hosted-hoprnet-bigger
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
       enable_integration_tests: true
       enable_unit_coverage: true
       enable_integration_coverage: true
-      runner: depot-ubuntu-24.04-16
+      runner_unit: depot-ubuntu-24.04-16
       runner_integration: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -96,8 +96,8 @@ jobs:
 - `benchmark_command` (Optional): Command for benchmarks (Default: `nix build .#bench-build`).
 - `unit_coverage_command` (Optional): Command for unit coverage (Default: `nix run .#coverage-unit`).
 - `integration_coverage_command` (Optional): Command for integration coverage (Default: `nix run .#coverage-integration`).
-- `runner` (Optional): Runner for unit tests, nightly tests, benchmarks, and unit coverage (Default: `ubuntu-latest`).
-- `runner_integration` (Optional): Runner for integration tests and integration coverage. Falls back to `runner` if empty (Default: `""`).
+- `runner_unit` (Optional): Runner for unit tests, nightly tests, benchmarks, and unit coverage (Default: `ubuntu-latest`).
+- `runner_integration` (Optional): Runner for integration tests and integration coverage. Falls back to `runner_unit` if empty (Default: `""`).
 - `test_timeout` (Optional): Timeout in minutes for test jobs (Default: `60`).
 - `benchmark_timeout` (Optional): Timeout in minutes for benchmark job (Default: `20`).
 - `coverage_timeout` (Optional): Timeout in minutes for coverage jobs (Default: `60`).
@@ -118,7 +118,7 @@ jobs:
       enable_integration_tests: false
       enable_unit_coverage: true
       enable_integration_coverage: true
-      runner: depot-ubuntu-24.04-16
+      runner_unit: depot-ubuntu-24.04-16
       runner_integration: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Add optional `runner_integration` input to `tests.yaml` reusable workflow - needed because of differing requirements under depot
- Integration tests and coverage use this runner when provided, falling back to `runner`
- Enables callers to use smaller runners for single-threaded integration tests while keeping larger runners for CPU-bound unit tests
- Fully backwards-compatible: existing callers that don't pass `runner_integration` behave identically

Depends on: https://github.com/hoprnet/hoprnet/pull/8029


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured CI workflow with separated test jobs for improved execution control
  * Updated workflow input naming conventions for clarity
  * Refactored coverage configuration with conditional execution based on test results
  * Updated workflow documentation and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->