### PR TITLE
fix: Bump version looses the referenced input.file

### DIFF
--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -100,7 +100,7 @@ runs:
               echo "Regenerating Cargo.lock file"
               nix develop --command bash -c "cargo metadata --no-deps --format-version 1 --manifest-path ${{ inputs.file }} \
                 | jq -r '.packages[] | select(.source == null) | .name' \
-                | xargs -I{} cargo update -p {}"
+                | xargs -I{} cargo update --manifest-path ${{ inputs.file }} -p {}"
             fi
           elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then
             jq --arg bump_version "${bump_version}" '.version = $bump_version' ${{ inputs.file }} > "${{ inputs.file }}.tmp"


### PR DESCRIPTION
Update cargo based on the `${{ inputs.file }}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Cargo lockfile regeneration to use explicit manifest path specification for enhanced reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->