### PR TITLE
feat: Externalize to parameter the Bucket to push SBOM analysis

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -52,6 +52,11 @@ on:
         type: string
         default: "docker"
         description: "Format to use when pushing docker images: 'docker' or 'skopeo'"
+      docker_bucket_sboms:
+        required: false
+        type: string
+        default: "docker-images-sboms"
+        description: "GCS bucket to upload SBOM files to for Google Artifact vulnerability analysis"
       timeout_minutes:
         required: false
         type: number
@@ -462,7 +467,7 @@ jobs:
           gcloud artifacts sbom load \
             --source sbom.json \
             --uri "${{ inputs.docker_gcp_registry }}/${{ inputs.docker_image_name }}:${{ steps.platform.outputs.docker_build_version_platform }}" \
-            --destination gs://docker-images-sboms
+            --destination gs://${{ inputs.docker_bucket_sboms }}
       - name: Log in to DockerHub
         if: needs.build.outputs.publish_docker_hub == 'true'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ jobs:
 **Inputs:**
 - `source_branch` (Required): Source branch to build the docker image from.
 - `version_type` (Required): The strategy for versioning (e.g., `commit`, `pr`, `release`).
-- `build_matrix`: It's a JSON array containing an object with the parameters for each matrix parallel execution.
+- `build_matrix`: It's a JSON array containing an object with the parameters for each matrix parallel execution. Each matrix entry must include its `runner`; this controls the `build` and `smoke-test` jobs
 - `cachix_cache_name` (Required): The name of the Cachix cache to use.
 - `build_file` (Optional): File to extract version from (Default: `Cargo.toml`).
 - `docker_image_name` (Required): The name of the image.
@@ -258,11 +258,10 @@ jobs:
 - `docker_gcp_registry` (Optional): Docker registry to push the image to (Default: `europe-west3-docker.pkg.dev/hoprassociation/docker-images`).
 - `docker_hub_registry` (Optional): Docker registry to push the image to (Default: `docker.io/hoprnet`).
 - `timeout_minutes` (Optional): Timeout for the job in minutes (Default: `60`).
-- `runner` (Optional): Runner to use for the job (Default: `self-hosted-hoprnet-bigger`).
 - `deployment_namespace` (Optional): Kubernetes namespace for the deployment to restart in staging.
 - `deployment_label_selector` (Optional): Kubernetes label selector for the deployment to restart in staging.
 - `fail_on_scan_vulnerabilities`: Whether to fail the build if vulnerabilities are found during the scan (Default: `true`)
-- `job_runner`: Runner to use for the build job
+- `job_runner` (Optional): Runner to use for non-matrix jobs (`manifest`, `scan`, `deploy`) (Default: `depot-ubuntu-22.04-4`)
 
 **Secrets:**
 - `gcp_service_account` (Required): Google Cloud Service Account with permissions to upload artifacts.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ jobs:
 - `build_file` (Optional): File to extract version from (Default: `Cargo.toml`).
 - `docker_image_name` (Required): The name of the image.
 - `docker_image_format`: (Optional): Type of format generated for the docker image: `docker` or `skopeo` (Default: `docker`).
+- `docker_bucket_sboms`: GCS bucket to upload SBOM files to for Google Artifact vulnerability analysis
 - `docker_gcp_registry` (Optional): Docker registry to push the image to (Default: `europe-west3-docker.pkg.dev/hoprassociation/docker-images`).
 - `docker_hub_registry` (Optional): Docker registry to push the image to (Default: `docker.io/hoprnet`).
 - `timeout_minutes` (Optional): Timeout for the job in minutes (Default: `60`).
@@ -261,6 +262,7 @@ jobs:
 - `deployment_namespace` (Optional): Kubernetes namespace for the deployment to restart in staging.
 - `deployment_label_selector` (Optional): Kubernetes label selector for the deployment to restart in staging.
 - `fail_on_scan_vulnerabilities`: Whether to fail the build if vulnerabilities are found during the scan (Default: `true`)
+- `job_runner`: Runner to use for the build job
 
 **Secrets:**
 - `gcp_service_account` (Required): Google Cloud Service Account with permissions to upload artifacts.


### PR DESCRIPTION
Add a new parameter into build-docker.yaml to allow specify the bucket name where to publish SBOM analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made GCS bucket destination for SBOM file uploads configurable in the Docker build workflow.

* **Documentation**
  * Updated build workflow documentation with new `docker_bucket_sboms` parameter for SBOM upload configuration.
  * Documented `job_runner` parameter for build runner selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->