### PR TITLE
feat: Allow to sign binaries using a GPG private key with passphrase

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -70,6 +70,8 @@ on:
         required: true
       gpg_private_key:
         required: false
+      gpg_private_key_password:
+        required: false
       apple_certificate:
         required: false
       apple_certificate_password:
@@ -167,6 +169,7 @@ jobs:
           path: ${{ github.workspace }}/artifacts/
           architecture: ${{ inputs.architecture }}
           gpg_private_key: ${{ secrets.gpg_private_key }}
+          gpg_private_key_password: ${{ secrets.gpg_private_key_password }}
           apple_certificate: ${{ secrets.apple_certificate }}
           apple_certificate_password: ${{ secrets.apple_certificate_password }}
       - name: Upload ${{ inputs.binary }}-${{ inputs.architecture }} signed binary

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ jobs:
 **Secrets:**
 - `gcp_service_account` (Required): Google Cloud Service Account with permissions to upload artifacts.
 - `gcp_workload_identity_provider`: The workload identity provider to authenticate on GCP.
-- `gcp_workload_identity_service_account`:The service account for the workload identity provider on GCP.
+- `gcp_workload_identity_service_account`: The service account for the workload identity provider on GCP.
 - `cachix_auth_token` (Required): Auth token for Cachix cache.
 - `gpg_private_key` (Required): GPG Key to sign the artifacts.
 - `gpg_private_key_password`: GPG private key password.

--- a/README.md
+++ b/README.md
@@ -193,8 +193,13 @@ jobs:
 
 **Secrets:**
 - `gcp_service_account` (Required): Google Cloud Service Account with permissions to upload artifacts.
+- `gcp_workload_identity_provider`: The workload identity provider to authenticate on GCP.
+- `gcp_workload_identity_service_account`:The service account for the workload identity provider on GCP.
 - `cachix_auth_token` (Required): Auth token for Cachix cache.
 - `gpg_private_key` (Required): GPG Key to sign the artifacts.
+- `gpg_private_key_password`: GPG private key password.
+- `apple_certificate`: Apple developer certificate p12 for signing in base64.
+- `apple_certificate_password`: Apple developer certificate password.
 
 **Outputs:**
 

--- a/actions/sign-file/README.md
+++ b/actions/sign-file/README.md
@@ -11,7 +11,9 @@ Creates file `${input.file}.asc` and `${input.file}.sha256`.
         with:
           path: ./binary-file
           gpg_private_key: ${{ secrets.MY_GPG_PRIVATE_KEY }}
-
+          gpg_private_key_password: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
+          apple_certificate: ${{ secrets.APPLE_CERTIFICATE_DEVELOPER_P12_BASE64 }}
+          apple_certificate_password: ${{ secrets.APPLE_CERTIFICATE_DEVELOPER_PASSWORD }}
 ```
 
 ## Requirements
@@ -22,10 +24,10 @@ None
 
 - `path`: The filepath to sign
 - `architecture`: Architecture of the file to sign (e.g. x86_64-linux, aarch64-linux, x86_64-darwin, etc.)
-- `gpg_private_key`: GPG private key for signing
-- `gpg_private_key_password`: GPG private key password
-- `apple_certificate`: Apple developer certificate p12 for signing in base64
-- `apple_certificate_password`: Apple developer certificate password
+- `gpg_private_key`: (Optional) GPG private key for signing
+- `gpg_private_key_password`: (Optional) GPG private key password
+- `apple_certificate`: (Optional) Apple developer certificate p12 for signing in base64
+- `apple_certificate_password`: (Optional) Apple developer certificate password
 
 ## Outputs
 

--- a/actions/sign-file/README.md
+++ b/actions/sign-file/README.md
@@ -23,6 +23,7 @@ None
 - `path`: The filepath to sign
 - `architecture`: Architecture of the file to sign (e.g. x86_64-linux, aarch64-linux, x86_64-darwin, etc.)
 - `gpg_private_key`: GPG private key for signing
+- `gpg_private_key_password`: GPG private key password
 - `apple_certificate`: Apple developer certificate p12 for signing in base64
 - `apple_certificate_password`: Apple developer certificate password
 

--- a/actions/sign-file/action.yaml
+++ b/actions/sign-file/action.yaml
@@ -10,6 +10,9 @@ inputs:
     gpg_private_key:
         description: GPG private key for signing
         required: false
+    gpg_private_key_password:
+        description: GPG private key password
+        required: false
     apple_certificate:
         description: Apple developer certificate p12 for signing in base64
         required: false
@@ -25,6 +28,7 @@ runs:
         run: ${{ github.action_path }}/sign-linux-file.sh "${{ inputs.path }}"
         env:
           GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
+          GPG_PRIVATE_KEY_PASSWORD: ${{ inputs.gpg_private_key_password }}
         working-directory: ${{ github.workspace }}
       - name: Sign darwin file
         if: contains(inputs.architecture, 'darwin')

--- a/actions/sign-file/sign-linux-file.sh
+++ b/actions/sign-file/sign-linux-file.sh
@@ -12,12 +12,18 @@ sign() {
     # Create isolated GPG keyring
     gnupghome="$(mktemp -d)"
     export GNUPGHOME="$gnupghome"
-    echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+    local gpg_passphrase_opts=()
+    if [[ -n "${GPG_PRIVATE_KEY_PASSWORD:-}" ]]; then
+        gpg_passphrase_opts=(--pinentry-mode loopback --passphrase "$GPG_PRIVATE_KEY_PASSWORD")
+    fi
+
+    echo "$GPG_PRIVATE_KEY" | gpg --batch "${gpg_passphrase_opts[@]}" --import
 
     # Generate hash and signature
     sha256sum "$input_file" > "$input_file.sha256"
     echo "Hash written to $input_file.sha256"
-    gpg --armor --output "$input_file.asc" --detach-sign "$input_file"
+    gpg --batch --armor --output "$input_file.asc" --detach-sign "${gpg_passphrase_opts[@]}" "$input_file"
     echo "Signature written to $input_file.asc"
 
     # Clean up


### PR DESCRIPTION
Currently the action `sign-file` only supports signing binaries using a GPG private key without password. Now it will support providing a passphrase for the GPG_PRIVATE_KEY to use to import it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for using a GPG private key passphrase when signing binaries.
  * Added optional Apple certificate signing support and expanded GCP authentication options.

* **Documentation**
  * Updated workflow and action docs to list new secrets/inputs for GPG passphrase, Apple certificate/password, and GCP workload identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->