### PR TITLE
fix: Release notes generations and download artifacts

### DIFF
--- a/actions/download-artifact-registry/action.yaml
+++ b/actions/download-artifact-registry/action.yaml
@@ -30,11 +30,12 @@ runs:
         shell: bash
         id: artifacts
         run: |
+          destination="${{ inputs.destination }}"
           # Set gcloud config defaults to avoid repeating flags
           gcloud config set artifacts/location "${{ inputs.region }}"
           gcloud config set artifacts/repository "${{ inputs.repository }}"
 
-          mkdir -p "${{ inputs.destination }}"
+          mkdir -p "${destination}"
           if ! files=$(gcloud artifacts files list \
             --package="${{ inputs.package }}" \
             --version="${{ inputs.version }}" \
@@ -53,7 +54,7 @@ runs:
             if ! gcloud artifacts generic download \
               --package="${{ inputs.package }}" \
               --version="${{ inputs.version }}" \
-              --destination="${{ inputs.destination }}" \
+              --destination="${destination}" \
               --name="${filename}"; then
               echo "Error: Failed to download ${filename}"
               exit 1

--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -73,6 +73,7 @@ runs:
           fetch-depth: 0
           fetch-tags: true
           token: ${{ inputs.github_token }}
+          clean: ${{ inputs.release_notes_file == '' }}
       - name: Get version info
         id: version
         uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v2


### PR DESCRIPTION
While releasing GnosisVPN projects found 2 bugs:
- The release-version action check out the repository cleaning the previous generated release notes.
- The download artifact action is not propagating correctly the destination folder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced artifact download action with improved destination path handling for better reliability.
  * Optimized release workflow cleanup behavior based on release notes configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->