### PR TITLE
feat(ci): add benchmarking logic

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -91,8 +91,9 @@ jobs:
       - name: Execute and Upload (PR)
         if: inputs.is_pr == true
         id: bencher_pr
+        shell: bash
         run: |
-          set -o pipefail
+          set +e
           bencher run \
             --project ${{ inputs.project }} \
             --token "${{ secrets.bencher_api_token }}" \
@@ -100,26 +101,32 @@ jobs:
             --branch "${{ inputs.source_branch }}" \
             --github-actions "${{ secrets.GITHUB_TOKEN }}" \
             --err \
-            "${{ inputs.run_command }}" | tee bencher_output.txt
+            "${{ inputs.run_command }}" 2>&1 | tee bencher_output.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
 
           # Extract Bencher Run URL
           BENCHER_RUN_URL=$(grep -oE "https://bencher.dev/(console/projects/${{ inputs.project }}/runs/|perf/${{ inputs.project }}/reports/)[^[:space:]]+" bencher_output.txt | head -n 1)
           echo "bencher_run_url=${BENCHER_RUN_URL:-https://bencher.dev/console/projects/${{ inputs.project }}}" >> "$GITHUB_OUTPUT"
+
+          exit $EXIT_CODE
         env:
           BENCHER_API_TOKEN: ${{ secrets.bencher_api_token }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Notify performance drop (PR)
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
-        if: failure() && inputs.is_pr == true && secrets.zulip_api_key != ''
+        if: failure() && inputs.is_pr == true && env.ZULIP_API_KEY != ''
+        env:
+          ZULIP_API_KEY: ${{ secrets.zulip_api_key }}
         with:
-          api-key: ${{ secrets.zulip_api_key }}
+          api-key: ${{ env.ZULIP_API_KEY }}
           email: ${{ secrets.zulip_email }}
           organization-url: "https://hopr.zulipchat.com"
           type: "stream"
           to: "HOPRd"
           topic: "Benchmark regressions"
           content: |
-            The benchmark results for PR `${{ github.event.pull_request.title }}` (#${{ github.event.pull_request.number }}) have dropped, or failed.
+            The benchmark results for PR `${{ github.event.pull_request.title || github.ref_name }}`${{ github.event.pull_request.number && format(' (#{0})', github.event.pull_request.number) || '' }} have dropped, or failed.
 
             Please check the specific [Bencher Run](${{ steps.bencher_pr.outputs.bencher_run_url }}) for more details.
       - name: Execute and Upload (Merge)
@@ -149,9 +156,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Notify performance drop (Merge)
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
-        if: failure() && inputs.is_pr == false && secrets.zulip_api_key != ''
+        if: failure() && inputs.is_pr == false && env.ZULIP_API_KEY != ''
+        env:
+          ZULIP_API_KEY: ${{ secrets.zulip_api_key }}
         with:
-          api-key: ${{ secrets.zulip_api_key }}
+          api-key: ${{ env.ZULIP_API_KEY }}
           email: ${{ secrets.zulip_email }}
           organization-url: "https://hopr.zulipchat.com"
           type: "stream"

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -8,40 +8,49 @@ on:
       runner:
         required: true
         type: string
-      project:
+      bencher_project:
         required: true
         type: string
         description: "Bencher project name"
-      run_benchmarks:
-        required: false
+      should_build:
+        required: true
         type: boolean
-        default: true
+        description: "Whether to build benchmarks"
+      should_run:
+        required: true
+        type: boolean
         description: "Whether to run benchmarks after building them"
-      is_pr:
-        required: false
-        type: boolean
-        default: false
-        description: "Whether this is running for a PR (uses PR branch and github actions commenting)"
       build_command:
-        required: false
+        required: true
         type: string
-        default: "nix build -L .#bench-build"
+        description: "Command to build benchmarks"
       run_command:
+        required: true
+        type: string
+        description: "Command to run benchmarks"
+      zulip_stream:
         required: false
         type: string
-        default: "nix run .#bench-run"
+        default: "HOPRd"
+        description: "Zulip stream name"
+      zulip_topic:
+        required: false
+        type: string
+        default: "Benchmark regressions"
+        description: "Zulip topic name"
     secrets:
       cachix_auth_token:
         required: true
       bencher_api_token:
         required: false
-      zulip_api_key:
+      ZULIP_API_KEY:
         required: false
-      zulip_email:
+      ZULIP_EMAIL:
         required: false
 jobs:
   build-benchmarks:
     name: Build Benchmarks
+    if: inputs.should_build == true
     runs-on: ${{ inputs.runner }}
     permissions:
       contents: read
@@ -65,7 +74,7 @@ jobs:
   run-benchmarks:
     name: Run Benchmarks
     needs: build-benchmarks
-    if: inputs.run_benchmarks == true
+    if: always() && inputs.should_run == true && (needs.build-benchmarks.result == 'success' || needs.build-benchmarks.result == 'skipped')
     runs-on: ${{ inputs.runner }}
     permissions:
       contents: read
@@ -89,13 +98,13 @@ jobs:
       - name: Install Bencher CLI
         uses: bencherdev/bencher@0f8f620172ccd6225d40a7590598eb7b41718af8
       - name: Execute and Upload (PR)
-        if: inputs.is_pr == true
+        if: github.event_name == 'pull_request'
         id: bencher_pr
         shell: bash
         run: |
           set +e
           bencher run \
-            --project ${{ inputs.project }} \
+            --project ${{ inputs.bencher_project }} \
             --token "${{ secrets.bencher_api_token }}" \
             --adapter rust_criterion \
             --branch "${{ inputs.source_branch }}" \
@@ -106,8 +115,8 @@ jobs:
           set -e
 
           # Extract Bencher Run URL
-          BENCHER_RUN_URL=$(grep -oE "https://bencher.dev/(console/projects/${{ inputs.project }}/runs/|perf/${{ inputs.project }}/reports/)[^[:space:]]+" bencher_output.txt | head -n 1)
-          echo "bencher_run_url=${BENCHER_RUN_URL:-https://bencher.dev/console/projects/${{ inputs.project }}}" >> "$GITHUB_OUTPUT"
+          BENCHER_RUN_URL=$(grep -oE "https://bencher.dev/(console/projects/${{ inputs.bencher_project }}/runs/|perf/${{ inputs.bencher_project }}/reports/)[^[:space:]]+" bencher_output.txt | head -n 1)
+          echo "bencher_run_url=${BENCHER_RUN_URL:-https://bencher.dev/console/projects/${{ inputs.bencher_project }}}" >> "$GITHUB_OUTPUT"
 
           exit $EXIT_CODE
         env:
@@ -115,29 +124,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Notify performance drop (PR)
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
-        if: failure() && inputs.is_pr == true && env.ZULIP_API_KEY != ''
+        if: failure() && github.event_name == 'pull_request' && env.ZULIP_API_KEY != '' && env.ZULIP_EMAIL != ''
         env:
-          ZULIP_API_KEY: ${{ secrets.zulip_api_key }}
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+          ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
         with:
           api-key: ${{ env.ZULIP_API_KEY }}
-          email: ${{ secrets.zulip_email }}
+          email: ${{ env.ZULIP_EMAIL }}
           organization-url: "https://hopr.zulipchat.com"
           type: "stream"
-          to: "HOPRd"
-          topic: "Benchmark regressions"
+          to: "${{ inputs.zulip_stream }}"
+          topic: "${{ inputs.zulip_topic }}"
           content: |
-            The benchmark results for PR `${{ github.event.pull_request.title || github.ref_name }}`${{ github.event.pull_request.number && format(' (#{0})', github.event.pull_request.number) || '' }} have dropped, or failed.
+            The Bencher results for PR `${{ github.event.pull_request.title || github.ref_name }}`${{ github.event.pull_request.number && format(' ([#{0}](https://github.com/{1}/pull/{0}))', github.event.pull_request.number, github.repository) || '' }} have dropped, or failed.
 
-            Please check the specific [Bencher Run](${{ steps.bencher_pr.outputs.bencher_run_url }}) for more details.
-      - name: Execute and Upload (Merge)
-        if: inputs.is_pr == false
+            Please check the specific [Bencher Run](${{ steps.bencher_pr.outputs.bencher_run_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}) for more details.
+      - name: Execute and Upload (Merge/Push)
+        if: github.event_name != 'pull_request'
         id: bencher_merge
         shell: bash
         run: |
           set +e
           # Capture stdout and stderr, tee to file
           bencher run \
-            --project ${{ inputs.project }} \
+            --project ${{ inputs.bencher_project }} \
             --token "${{ secrets.bencher_api_token }}" \
             --adapter rust_criterion \
             --branch "${{ inputs.source_branch }}" \
@@ -147,26 +157,27 @@ jobs:
           set -e
 
           # Extract Bencher Report URL
-          BENCHER_REPORT_URL=$(grep -oE "https://bencher.dev/(console/projects/${{ inputs.project }}/reports/|perf/${{ inputs.project }}/reports/)[^[:space:]]+" bencher_output.txt | head -n 1)
-          echo "bencher_report_url=${BENCHER_REPORT_URL:-https://bencher.dev/console/projects/${{ inputs.project }}}" >> "$GITHUB_OUTPUT"
+          BENCHER_REPORT_URL=$(grep -oE "https://bencher.dev/(console/projects/${{ inputs.bencher_project }}/reports/|perf/${{ inputs.bencher_project }}/reports/)[^[:space:]]+" bencher_output.txt | head -n 1)
+          echo "bencher_report_url=${BENCHER_REPORT_URL:-https://bencher.dev/console/projects/${{ inputs.bencher_project }}}" >> "$GITHUB_OUTPUT"
 
           exit $EXIT_CODE
         env:
           BENCHER_API_TOKEN: ${{ secrets.bencher_api_token }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Notify performance drop (Merge)
+      - name: Notify performance drop (Merge/Push)
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
-        if: failure() && inputs.is_pr == false && env.ZULIP_API_KEY != ''
+        if: failure() && github.event_name != 'pull_request' && env.ZULIP_API_KEY != '' && env.ZULIP_EMAIL != ''
         env:
-          ZULIP_API_KEY: ${{ secrets.zulip_api_key }}
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+          ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
         with:
           api-key: ${{ env.ZULIP_API_KEY }}
-          email: ${{ secrets.zulip_email }}
+          email: ${{ env.ZULIP_EMAIL }}
           organization-url: "https://hopr.zulipchat.com"
           type: "stream"
-          to: "HOPRd"
-          topic: "Benchmark regressions"
+          to: "${{ inputs.zulip_stream }}"
+          topic: "${{ inputs.zulip_topic }}"
           content: |
-            The benchmark results for branch `${{ github.repository }} ${{ github.ref_name }}` at commit (${{ github.sha }}) have dropped, or failed.
+            The Bencher results for branch `${{ github.repository }} ${{ github.ref_name }}` at commit (${{ github.sha }}) have dropped, or failed.
 
-            Please check the specific [Bencher Report](${{ steps.bencher_merge.outputs.bencher_report_url }}) for more details.
+            Please check the specific [Bencher Report](${{ steps.bencher_merge.outputs.bencher_report_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}) for more details.

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,163 @@
+name: Benchmarks
+on:
+  workflow_call:
+    inputs:
+      source_branch:
+        required: true
+        type: string
+      runner:
+        required: true
+        type: string
+      project:
+        required: true
+        type: string
+        description: "Bencher project name"
+      run_benchmarks:
+        required: false
+        type: boolean
+        default: true
+        description: "Whether to run benchmarks after building them"
+      is_pr:
+        required: false
+        type: boolean
+        default: false
+        description: "Whether this is running for a PR (uses PR branch and github actions commenting)"
+      build_command:
+        required: false
+        type: string
+        default: "nix build -L .#bench-build"
+      run_command:
+        required: false
+        type: string
+        default: "nix run .#bench-run"
+    secrets:
+      cachix_auth_token:
+        required: true
+      bencher_api_token:
+        required: false
+      zulip_api_key:
+        required: false
+      zulip_email:
+        required: false
+jobs:
+  build-benchmarks:
+    name: Build Benchmarks
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.source_branch }}
+      - name: Setup Nix
+        uses: hoprnet/hopr-workflows/actions/setup-nix@43b03a7b5df777770d95c6524f48be34184b26fa # setup-nix-v1
+        with:
+          cachix_auth_token: ${{ secrets.cachix_auth_token }}
+      - name: Build benchmarks
+        run: ${{ inputs.build_command }}
+  run-benchmarks:
+    name: Run Benchmarks
+    needs: build-benchmarks
+    if: inputs.run_benchmarks == true
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.source_branch }}
+      - name: Setup Nix
+        uses: hoprnet/hopr-workflows/actions/setup-nix@43b03a7b5df777770d95c6524f48be34184b26fa # setup-nix-v1
+        with:
+          cachix_auth_token: ${{ secrets.cachix_auth_token }}
+      - name: Install Bencher CLI
+        uses: bencherdev/bencher@0f8f620172ccd6225d40a7590598eb7b41718af8
+      - name: Execute and Upload (PR)
+        if: inputs.is_pr == true
+        id: bencher_pr
+        run: |
+          set -o pipefail
+          bencher run \
+            --project ${{ inputs.project }} \
+            --token "${{ secrets.bencher_api_token }}" \
+            --adapter rust_criterion \
+            --branch "${{ inputs.source_branch }}" \
+            --github-actions "${{ secrets.GITHUB_TOKEN }}" \
+            --err \
+            "${{ inputs.run_command }}" | tee bencher_output.txt
+
+          # Extract Bencher Run URL
+          BENCHER_RUN_URL=$(grep -oE "https://bencher.dev/(console/projects/${{ inputs.project }}/runs/|perf/${{ inputs.project }}/reports/)[^[:space:]]+" bencher_output.txt | head -n 1)
+          echo "bencher_run_url=${BENCHER_RUN_URL:-https://bencher.dev/console/projects/${{ inputs.project }}}" >> "$GITHUB_OUTPUT"
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.bencher_api_token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Notify performance drop (PR)
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+        if: failure() && inputs.is_pr == true && secrets.zulip_api_key != ''
+        with:
+          api-key: ${{ secrets.zulip_api_key }}
+          email: ${{ secrets.zulip_email }}
+          organization-url: "https://hopr.zulipchat.com"
+          type: "stream"
+          to: "HOPRd"
+          topic: "Benchmark regressions"
+          content: |
+            The benchmark results for PR `${{ github.event.pull_request.title }}` (#${{ github.event.pull_request.number }}) have dropped, or failed.
+
+            Please check the specific [Bencher Run](${{ steps.bencher_pr.outputs.bencher_run_url }}) for more details.
+      - name: Execute and Upload (Merge)
+        if: inputs.is_pr == false
+        id: bencher_merge
+        shell: bash
+        run: |
+          set +e
+          # Capture stdout and stderr, tee to file
+          bencher run \
+            --project ${{ inputs.project }} \
+            --token "${{ secrets.bencher_api_token }}" \
+            --adapter rust_criterion \
+            --branch "${{ inputs.source_branch }}" \
+            --err \
+            "${{ inputs.run_command }}" 2>&1 | tee bencher_output.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          # Extract Bencher Report URL
+          BENCHER_REPORT_URL=$(grep -oE "https://bencher.dev/(console/projects/${{ inputs.project }}/reports/|perf/${{ inputs.project }}/reports/)[^[:space:]]+" bencher_output.txt | head -n 1)
+          echo "bencher_report_url=${BENCHER_REPORT_URL:-https://bencher.dev/console/projects/${{ inputs.project }}}" >> "$GITHUB_OUTPUT"
+
+          exit $EXIT_CODE
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.bencher_api_token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Notify performance drop (Merge)
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+        if: failure() && inputs.is_pr == false && secrets.zulip_api_key != ''
+        with:
+          api-key: ${{ secrets.zulip_api_key }}
+          email: ${{ secrets.zulip_email }}
+          organization-url: "https://hopr.zulipchat.com"
+          type: "stream"
+          to: "HOPRd"
+          topic: "Benchmark regressions"
+          content: |
+            The benchmark results for branch `${{ github.repository }} ${{ github.ref_name }}` at commit (${{ github.sha }}) have dropped, or failed.
+
+            Please check the specific [Bencher Report](${{ steps.bencher_merge.outputs.bencher_report_url }}) for more details.

--- a/README.md
+++ b/README.md
@@ -333,3 +333,54 @@ jobs:
 **Outputs:**
 
 - No outputs defined.
+
+---
+
+### [Benchmarks](./.github/workflows/benchmarks.yaml)
+
+Standardized workflow for building, running, and publishing benchmarks to Bencher.dev, with integrated Zulip notifications for performance drops or failures.
+
+**Usage:**
+
+```yaml
+jobs:
+  benchmarks:
+    name: Benchmarks
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    uses: hoprnet/hopr-workflows/.github/workflows/benchmarks.yaml@<commit-hash> # main
+    with:
+      source_branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      runner: self-hosted-hoprnet-bigger
+      bencher_project: ${{ github.event.repository.name }}
+      should_build: true
+      should_run: true
+      build_command: "nix build -L .#bench-build"
+      run_command: "nix run .#bench-run"
+    secrets:
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      bencher_api_token: ${{ secrets.BENCHER_API_TOKEN }}
+      ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+      ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
+```
+
+**Inputs:**
+
+- `source_branch` (Required): Source branch to check out.
+- `runner` (Required): The runner label to use for the jobs.
+- `bencher_project` (Required): The project name in Bencher.dev.
+- `should_build` (Required): Whether to build the benchmarks.
+- `should_run` (Required): Whether to run benchmarks after building them.
+- `build_command` (Required): Command to build the benchmarks.
+- `run_command` (Required): Command to run the benchmarks.
+- `zulip_stream` (Optional): Zulip stream for notifications (Default: `"HOPRd"`).
+- `zulip_topic` (Optional): Zulip topic for notifications (Default: `"Benchmark regressions"`).
+
+**Secrets:**
+
+- `cachix_auth_token` (Required): Auth token for Cachix cache.
+- `bencher_api_token` (Optional): API token for Bencher.dev.
+- `ZULIP_API_KEY` (Optional): Zulip API key for notifications.
+- `ZULIP_EMAIL` (Optional): Zulip email for notifications.


### PR DESCRIPTION
Moved and unified benchmarking logic from hopr-types and hoprnet
Example usage can be seen in:
- https://github.com/hoprnet/hoprnet/pull/8069
- https://github.com/hoprnet/hopr-types/pull/42
Connected too #51 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a reusable CI workflow to build and run benchmarks with configurable build/run commands, runner selection, and toggles for build and execute; preserves benchmark tool exit codes and handles PR vs non-PR runs differently, exposing run/report URLs.
* **Documentation**
  * Added usage and input/secret docs for the new benchmarks workflow, including optional Zulip notifications for failures or regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->