### PR TITLE
fix: Fixes concurrency issue when the repository builds 2 different binaries in the matrix

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -76,7 +76,7 @@ on:
       apple_certificate_password:
         required: false
 concurrency:
-  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-${{ inputs.architecture }}-binary
+  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-${{ inputs.architecture }}-${{ inputs.binary }}-build-binary
   cancel-in-progress: true
 permissions:
   contents: read


### PR DESCRIPTION
The current workflow was not discriminating the concurrency based on the binary. There are projects which contain different binaries to build in the same matrix. This fixes the concurrency issue.