### PR TITLE
fix: Fix bump version regular expression

### DIFF
--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -94,7 +94,7 @@ runs:
 
         # Update the version in the specified file
         if [[ "${{ inputs.file }}" =~ .*\.toml$ ]]; then
-          sed -i.bak -E "s/(^version = \")([0-9]+\.[0-9]+\.[0-9]+)(-rc\.[0-9]+)?(\+.*)?(\")/\1${bump_version}\5/" ${{ inputs.file }}
+          sed -i.bak -E "s/(^version\s*=\s*\")([0-9]+\.[0-9]+\.[0-9]+)(-rc\.[0-9]+)?(\+.*)?(\")/\1${bump_version}\5/" ${{ inputs.file }}
           rm "${{ inputs.file }}.bak"
           if [[ "${{ inputs.file }}" =~ .*Cargo\.toml$ ]]; then
             echo "Regenerating Cargo.lock file"


### PR DESCRIPTION
Fixes the `bump-version` reusable action to make the sentence that bumps the input.file resilient to multiple spaces when it's a Cargo.toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version bump tool to handle flexible formatting in version configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->