### PR TITLE
fix: hash sha256 file contains absolute path from CI

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -180,12 +180,12 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ inputs.binary }}-${{ inputs.architecture}}.asc
-          path: ${{ github.workspace }}/artifacts/${{ inputs.binary }}-${{ inputs.architecture}}.asc
+          path: ${{ github.workspace }}/artifacts/*-${{ inputs.architecture}}.asc
       - name: Upload ${{ inputs.binary }}-${{ inputs.architecture }} binary checksum
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ inputs.binary }}-${{ inputs.architecture}}.sha256
-          path: ${{ github.workspace }}/artifacts/${{ inputs.binary }}-${{ inputs.architecture}}.sha256
+          path: ${{ github.workspace }}/artifacts/*-${{ inputs.architecture}}.sha256
       - name: Setup GCP
         if: needs.build.outputs.publish_artifact_registry == 'true'
         uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -173,7 +173,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ inputs.binary }}-${{ inputs.architecture }}
-          path: ${{ github.workspace }}/artifacts/${{ inputs.binary }}-${{ inputs.architecture }}
+          path: ${{ github.workspace }}/artifacts/*-${{ inputs.architecture }}
           overwrite: true
       - name: Upload ${{ inputs.binary }}-${{ inputs.architecture }} binary signature
         if: contains(inputs.architecture, 'linux')

--- a/actions/sign-file/sign-darwin-file.sh
+++ b/actions/sign-file/sign-darwin-file.sh
@@ -16,7 +16,14 @@ sign() {
   echo "Verifying signature for file $input_file"
   codesign --verify --deep --strict --verbose=4 "$input_file"
 
-  shasum -a 256 "$input_file" >"${input_file}.sha256"
+  local input_dir
+  local input_basename
+  input_dir="$(dirname "$input_file")"
+  input_basename="$(basename "$input_file")"
+  (
+    cd "$input_dir"
+    shasum -a 256 "$input_basename" >"${input_basename}.sha256"
+  )
   echo "Hash written to $input_file.sha256"
 
 }

--- a/actions/sign-file/sign-linux-file.sh
+++ b/actions/sign-file/sign-linux-file.sh
@@ -25,8 +25,10 @@ sign() {
   local input_basename
   input_dir="$(dirname "$input_file")"
   input_basename="$(basename "$input_file")"
-  cd "$input_dir"
-  sha256sum "$input_basename" >"$input_file.sha256"
+  (
+    cd "$input_dir"
+    sha256sum "$input_basename" >"$input_basename.sha256"
+  )
   echo "Hash written to $input_file.sha256"
   gpg --batch --armor --output "$input_file.asc" --detach-sign "${gpg_passphrase_opts[@]}" "$input_file"
   echo "Signature written to $input_file.asc"

--- a/actions/sign-file/sign-linux-file.sh
+++ b/actions/sign-file/sign-linux-file.sh
@@ -21,7 +21,12 @@ sign() {
   echo "$GPG_PRIVATE_KEY" | gpg --batch "${gpg_passphrase_opts[@]}" --import
 
   # Generate hash and signature
-  sha256sum "$input_file" >"$input_file.sha256"
+  local input_dir
+  local input_basename
+  input_dir="$(dirname "$input_file")"
+  input_basename="$(basename "$input_file")"
+  cd "$input_dir"
+  sha256sum "$input_basename" >"$input_file.sha256"
   echo "Hash written to $input_file.sha256"
   gpg --batch --armor --output "$input_file.asc" --detach-sign "${gpg_passphrase_opts[@]}" "$input_file"
   echo "Signature written to $input_file.asc"


### PR DESCRIPTION
- The hash file generated was containing the full path of the CI which does not exist when the user wants to check if the hash file is valid
- Fixes the filename of signed and hash artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file signing process to correctly handle file path operations when generating verification hashes. The cryptographic signature generation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->