### PR TITLE
feat: Add cleanup task for npm packages

### DIFF
--- a/.github/workflows/cleanup-registry.yaml
+++ b/.github/workflows/cleanup-registry.yaml
@@ -36,7 +36,10 @@ jobs:
           cachix_auth_token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Cleanup Docker images
         timeout-minutes: 20
-        run: nix run .#cleanup-docker-images -- "${{ vars.DOCKER_IMAGE_REGISTRY }}"
+        run: nix run .#cleanup-docker-images -- -p hoprassociation -l europe-west3 -r docker-images
       - name: Cleanup Artifact files
         timeout-minutes: 20
         run: nix run .#cleanup-artifact-files -- -p hoprassociation -l europe-west3 -r rust-binaries
+      - name: Cleanup NPM packages
+        timeout-minutes: 20
+        run: nix run .#cleanup-npm-packages -- -p hoprassociation -l europe-west3 -r npm

--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -70,8 +70,10 @@ runs:
         echo "Gathering version from ${{ inputs.file }} and setting build version type to '${{ inputs.version_type }}'"
         if [[ "${{ inputs.file }}" =~ ^.*\.toml$ ]]; then
           current_version=$(grep -E '^version\s*=' ${{ inputs.file }} | awk -F\" '{print $2}')
+          semver_delimiter="+"
         elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then
           current_version=$(jq -r '.version' ${{ inputs.file }})
+          semver_delimiter="-"
         else
           echo "Unsupported file type: ${{ inputs.file }}"
           exit 1
@@ -91,8 +93,8 @@ runs:
           commit_sha=$(git rev-parse --short HEAD)
           echo "Using HEAD SHA: ${commit_sha}"
         fi
-        commit_version="${current_version}+commit.${commit_sha}"
-        pr_version="${current_version}+pr.${{ github.event.pull_request.number }}"
+        commit_version="${current_version}${semver_delimiter}commit.${commit_sha}"
+        pr_version="${current_version}${semver_delimiter}pr.${{ github.event.pull_request.number }}"
         release_version="${current_version}"
         publish_artifact_registry=false
         publish_github_release=false
@@ -131,7 +133,7 @@ runs:
 
         ## Debug build flavor
         if [[ "${{ inputs.version_type }}" == "commit" ]] && [[ "${GITHUB_PR_LABEL_BUILD_FLAVOR_DEBUG:-0}" == '1' ]]; then
-            debug_version="${current_version}+debug.${commit_sha}"
+            debug_version="${current_version}${semver_delimiter}debug.${commit_sha}"
             docker_debug_version=${debug_version/+/-}
             if [[ "${{ inputs.architecture }}" == "aarch64-linux" ]]; then
               docker_debug_version_platform="${docker_debug_version}-linux-arm64"

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,11 @@
               exec ${pythonEnv.interpreter} ./scripts/cleanup-artifact-files.py "$@"
             '';
           };
+          apps.cleanup-npm-packages = flake-utils.lib.mkApp {
+            drv = pkgs.writeShellScriptBin "cleanup-npm-packages" ''
+              exec ${pythonEnv.interpreter} ./scripts/cleanup-npm-packages.py "$@"
+            '';
+          };
         };
     };
 }

--- a/scripts/cleanup-artifact-files.py
+++ b/scripts/cleanup-artifact-files.py
@@ -119,7 +119,9 @@ async def main():
             and name_filter.match(file.name)
         ]
         print(f"Found {len(old_files)} old files for {package}")
-        await delete_in_batches(old_files, lambda file: delete_old_file(client, file, dry_run))
+        await delete_in_batches(
+            old_files, lambda file: delete_old_file(client, file, dry_run)
+        )
 
 
 asyncio.run(main())

--- a/scripts/cleanup-artifact-files.py
+++ b/scripts/cleanup-artifact-files.py
@@ -88,7 +88,7 @@ async def delete_old_file(client, file, dry_run):
 
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description="Cleanup old artifacts.")
-add_args(parser, repository_default="rust-binaries")
+add_args(parser, repository_default="rust-binaries", project_required=True)
 args = parser.parse_args()
 
 project = args.project

--- a/scripts/cleanup-artifact-files.py
+++ b/scripts/cleanup-artifact-files.py
@@ -4,7 +4,7 @@
 # ///
 
 """
-cleanup-artifacts.py.py
+cleanup-artifacts.py
 
 This script cleans up old artifacts from a Google Cloud Artifact Registry.
 It lists artifacts in the specified registry, identifies artifacts older than
@@ -16,7 +16,7 @@ Dependencies:
 - google-auth==2.38.0
 
 Usage:
-    ./cleanup-artifacts.py.py <project> <region> <repository> [-n | --dry-run] [-d | --days <days>]
+    ./cleanup-artifacts.py <project> <region> <repository> [-n | --dry-run] [-d | --days <days>]
 
 Arguments:
     project: The GCP project ID.
@@ -26,44 +26,45 @@ Arguments:
     -d, --days: Number of days to consider a file old (default: 60).
 
 Example:
-    ./cleanup-artifacts.py.py my-project europe-west3 rust-binaries -d 30 --dry-run
+    ./cleanup-artifacts.py my-project europe-west3 rust-binaries -d 30 --dry-run
 """
 
-from datetime import UTC, datetime, timedelta
-from google.auth.exceptions import DefaultCredentialsError
+import importlib.util
+import os
+
+_spec = importlib.util.spec_from_file_location(
+    "cleanup_common",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "cleanup-common.py"),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+add_args = _mod.add_args
+make_cutoff_date = _mod.make_cutoff_date
+make_artifact_client = _mod.make_artifact_client
+make_registry_parent = _mod.make_registry_parent
+delete_in_batches = _mod.delete_in_batches
+
+from datetime import UTC
 from google.cloud import artifactregistry_v1
 import argparse
-import shlex
 import asyncio
-import itertools
 import re
-import subprocess
 import sys
 
 
-def list_files(client, parent, filter_str=None):
+def list_files(client, parent):
     """Lists Files in Artifact registry."""
     try:
-        print(f"Listing Files in {parent} with filter: {filter_str}")
-        request = artifactregistry_v1.ListFilesRequest(parent=parent, filter=filter_str)
-        return [file for file in client.list_files(request=request)]
+        print(f"Listing Files in {parent}")
+        request = artifactregistry_v1.ListFilesRequest(parent=parent)
+        return list(client.list_files(request=request))
     except Exception as e:
         print(f"Error listing artifact files: {str(e)}", file=sys.stderr)
         sys.exit(1)
 
 
-async def delete_old_files_list(client, files, dry_run):
-    """Deletes a list of artifact files asynchronously."""
-    await asyncio.gather(
-        *[
-            asyncio.wait_for(delete_old_file(client, file, dry_run), timeout=60)
-            for file in files
-        ]
-    )
-
-
 async def delete_old_file(client, file, dry_run):
-    """Deletes an artifact file by its URI."""
+    """Deletes an artifact file by its resource name."""
     full_file_name = file.name.split("/")[-1]
     package = full_file_name.split(":")[0]
     version = full_file_name.split(":")[1]
@@ -87,51 +88,26 @@ async def delete_old_file(client, file, dry_run):
 
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description="Cleanup old artifacts.")
-parser.add_argument("-p", "--project", help="GCP project ID")
-parser.add_argument(
-    "-l", "--location", default="europe-west3", help="Region of the Artifact Registry"
-)
-parser.add_argument(
-    "-r", "--repository", default="rust-binaries", help="Artifact repository name"
-)
-parser.add_argument(
-    "-n",
-    "--dry-run",
-    action="store_true",
-    help="Simulate the deletion without making any changes",
-)
-parser.add_argument(
-    "-d",
-    "--days",
-    type=int,
-    default=60,
-    help="Number of days to consider an file old (default: 60)",
-)
+add_args(parser, repository_default="rust-binaries")
 args = parser.parse_args()
 
-# Extract and validate command-line arguments
 project = args.project
 location = args.location
 repository = args.repository
 dry_run = args.dry_run
-days = args.days
-date = datetime.now(UTC) - timedelta(days=days)
+date = make_cutoff_date(args.days)
 packages = ["bloklid", "hopli"]
+
+# we are fine deleting files with a single "-commit.", "-pr.", "-build.", "-debug." or "<commit-hash>"
+# tag or with both
+name_filter = re.compile(r"^(.*\+commit\..*)|(.*\+pr\..*)|(.*\+debug\..*)")
 
 
 async def main():
     """Main function to clean up old Artifact Registry artifacts."""
-    try:
-        client = artifactregistry_v1.ArtifactRegistryClient()
-    except DefaultCredentialsError as e:
-        print(f"Error with credentials: {str(e)}", file=sys.stderr)
-        sys.exit(1)
+    client = make_artifact_client()
 
-    # we are fine deleting files with a single "-commit.", "-pr.", "-build.", "-debug." or "<commit-hash>"
-    # tag or with both
-    name_filter = re.compile(r"^(.*\+commit\..*)|(.*\+pr\..*)|(.*\+debug\..*)")
-    parent = f"projects/{project}/locations/{location}/repositories/{repository}"
-    # List all files in the repository (client-side filtering is more robust for partial matching)
+    parent = make_registry_parent(project, location, repository)
     artifact_files = list_files(client, parent)
     for package in packages:
         old_files = [
@@ -143,8 +119,7 @@ async def main():
             and name_filter.match(file.name)
         ]
         print(f"Found {len(old_files)} old files for {package}")
-        for batch in itertools.batched(old_files, 20):
-            await delete_old_files_list(client, batch, dry_run)
+        await delete_in_batches(old_files, lambda file: delete_old_file(client, file, dry_run))
 
 
 asyncio.run(main())

--- a/scripts/cleanup-common.py
+++ b/scripts/cleanup-common.py
@@ -15,11 +15,34 @@ import sys
 
 def add_args(parser, repository_default="", project_required=False):
     """Adds all standard arguments shared by all cleanup scripts."""
-    parser.add_argument("-p", "--project", required=project_required, help="GCP project ID")
-    parser.add_argument("-l", "--location", default="europe-west3", help="Region of the Artifact Registry")
-    parser.add_argument("-r", "--repository", default=repository_default, help="Artifact repository name")
-    parser.add_argument("-n", "--dry-run", action="store_true", help="Simulate the deletion without making any changes")
-    parser.add_argument("-d", "--days", type=int, default=60, help="Number of days to consider an item old (default: 60)")
+    parser.add_argument(
+        "-p", "--project", required=project_required, help="GCP project ID"
+    )
+    parser.add_argument(
+        "-l",
+        "--location",
+        default="europe-west3",
+        help="Region of the Artifact Registry",
+    )
+    parser.add_argument(
+        "-r",
+        "--repository",
+        default=repository_default,
+        help="Artifact repository name",
+    )
+    parser.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help="Simulate the deletion without making any changes",
+    )
+    parser.add_argument(
+        "-d",
+        "--days",
+        type=int,
+        default=60,
+        help="Number of days to consider an item old (default: 60)",
+    )
 
 
 def make_cutoff_date(days):

--- a/scripts/cleanup-common.py
+++ b/scripts/cleanup-common.py
@@ -1,0 +1,49 @@
+"""
+cleanup-common.py
+
+Shared utilities for the GCP Artifact Registry cleanup scripts.
+Not intended to be run directly — loaded via importlib from the other scripts.
+"""
+
+from datetime import UTC, datetime, timedelta
+from google.auth.exceptions import DefaultCredentialsError
+from google.cloud import artifactregistry_v1
+import asyncio
+import itertools
+import sys
+
+
+def add_args(parser, repository_default="", project_required=False):
+    """Adds all standard arguments shared by all cleanup scripts."""
+    parser.add_argument("-p", "--project", required=project_required, help="GCP project ID")
+    parser.add_argument("-l", "--location", default="europe-west3", help="Region of the Artifact Registry")
+    parser.add_argument("-r", "--repository", default=repository_default, help="Artifact repository name")
+    parser.add_argument("-n", "--dry-run", action="store_true", help="Simulate the deletion without making any changes")
+    parser.add_argument("-d", "--days", type=int, default=60, help="Number of days to consider an item old (default: 60)")
+
+
+def make_cutoff_date(days):
+    """Returns a UTC datetime representing `days` days ago."""
+    return datetime.now(UTC) - timedelta(days=days)
+
+
+def make_artifact_client():
+    """Creates an ArtifactRegistryClient, exiting on credential errors."""
+    try:
+        return artifactregistry_v1.ArtifactRegistryClient()
+    except DefaultCredentialsError as e:
+        print(f"Error with credentials: {str(e)}", file=sys.stderr)
+        sys.exit(1)
+
+
+def make_registry_parent(project, location, repository):
+    """Builds the Artifact Registry resource parent path."""
+    return f"projects/{project}/locations/{location}/repositories/{repository}"
+
+
+async def delete_in_batches(items, delete_fn, batch_size=20):
+    """Deletes items in batches, running each batch concurrently with a 60s timeout."""
+    for batch in itertools.batched(items, batch_size):
+        await asyncio.gather(
+            *[asyncio.wait_for(delete_fn(item), timeout=60) for item in batch]
+        )

--- a/scripts/cleanup-docker-images.py
+++ b/scripts/cleanup-docker-images.py
@@ -16,27 +16,47 @@ Dependencies:
 - google-auth==2.38.0
 
 Usage:
-    ./cleanup-docker-images.py <registry> [-n | --dry-run] [-d | --days <days>]
+    ./cleanup-docker-images.py -p <project> [-l <location>] [-r <repository>] [-n] [-d <days>]
 
 Arguments:
-    registry: The Docker image registry in the format `location-docker.pkg.dev/project/repo`.
+    -p, --project: The GCP project ID.
+    -l, --location: The region of the Artifact Registry (default: europe-west3).
+    -r, --repository: The Docker repository name in Artifact Registry.
     -n, --dry-run: Simulate the deletion without making any changes.
     -d, --days: Number of days to consider an image old (default: 60).
 
 Example:
-    ./cleanup-docker-images.py europe-west3-docker.pkg.dev/my-project/my-repo -d 30 --dry-run
+    ./cleanup-docker-images.py -p my-project -l europe-west3 -r hoprnet-gcr -d 30 --dry-run
 """
 
-from datetime import UTC, datetime, timedelta
-from google.auth.exceptions import DefaultCredentialsError
+import importlib.util
+import os
+
+_spec = importlib.util.spec_from_file_location(
+    "cleanup_common",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "cleanup-common.py"),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+add_args = _mod.add_args
+make_cutoff_date = _mod.make_cutoff_date
+make_artifact_client = _mod.make_artifact_client
+make_registry_parent = _mod.make_registry_parent
+delete_in_batches = _mod.delete_in_batches
+
+from datetime import UTC
 from google.cloud import artifactregistry_v1
 import argparse
-import shlex
 import asyncio
-import itertools
 import re
+import shlex
 import subprocess
 import sys
+
+
+def make_docker_registry(location, project, repository):
+    """Builds the Docker image registry URL for GCP Artifact Registry."""
+    return f"{location}-docker.pkg.dev/{project}/{repository}"
 
 
 def list_docker_images(client, parent):
@@ -44,20 +64,10 @@ def list_docker_images(client, parent):
     try:
         print(f"Listing Docker images in {parent}")
         request = artifactregistry_v1.ListDockerImagesRequest(parent=parent)
-        return [image for image in client.list_docker_images(request=request)]
+        return list(client.list_docker_images(request=request))
     except Exception as e:
         print(f"Error listing Docker images: {str(e)}", file=sys.stderr)
         sys.exit(1)
-
-
-async def delete_docker_images_list(images, dry_run):
-    """Deletes a list of Docker images asynchronously."""
-    await asyncio.gather(
-        *[
-            asyncio.wait_for(delete_docker_image(img, dry_run), timeout=60)
-            for img in images
-        ]
-    )
 
 
 async def delete_docker_image(img, dry_run):
@@ -72,7 +82,6 @@ async def delete_docker_image(img, dry_run):
     try:
         # Use gcloud CLI because Docker image deletion is not supported by the Artifact Registry client
         cmd = f"gcloud artifacts docker images delete {img.uri} --delete-tags -q"
-        # Run process capturing output to check for specific error messages
         subprocess.run(shlex.split(cmd), check=True, capture_output=True, text=True)
         print(f"Deleted Docker image {image_tag}")
     except subprocess.CalledProcessError as e:
@@ -84,27 +93,15 @@ async def delete_docker_image(img, dry_run):
 
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description="Cleanup old Docker images.")
-parser.add_argument("registry", help="Docker image registry")
-parser.add_argument(
-    "-n",
-    "--dry-run",
-    action="store_true",
-    help="Simulate the deletion without making any changes",
-)
-parser.add_argument(
-    "-d",
-    "--days",
-    type=int,
-    default=60,
-    help="Number of days to consider an image old (default: 60)",
-)
+add_args(parser)
 args = parser.parse_args()
 
-# Extract and validate command-line arguments
-registry = args.registry
+project = args.project
+location = args.location
+repository = args.repository
 dry_run = args.dry_run
-days = args.days
-date = datetime.now(UTC) - timedelta(days=days)
+date = make_cutoff_date(args.days)
+registry = make_docker_registry(location, project, repository)
 images = [
     "hoprd",
     "bloklid",
@@ -118,32 +115,12 @@ images = [
 # Docker images generated without Nix and with referenced images which cannot be deleted
 # images = ["hoprd-operator", "uhttp-latency-monitor", "hopr-pluto", "network-hoprnet-org", "network-hoprnet-org-be", "webapi-hoprnet-org"]
 
-# Example registry URL: europe-west3-docker.pkg.dev/my-project/my-repo
-registry_pattern = re.compile(
-    r"^(?P<location>[a-z0-9-]+)-docker\.pkg\.dev/(?P<project>[^/]+)/(?P<repo>[^/]+)$"
-)
-match = registry_pattern.match(registry)
-
-if not match:
-    print(f"Invalid registry format: {registry}", file=sys.stderr)
-    sys.exit(1)
-
-# Extract location, project, and repository from the registry URL
-location = match.group("location")
-project = match.group("project")
-repo = match.group("repo")
-
 
 async def main():
     """Main function to clean up old Docker images."""
-    try:
-        client = artifactregistry_v1.ArtifactRegistryClient()
-    except DefaultCredentialsError as e:
-        print(f"Error with credentials: {str(e)}", file=sys.stderr)
-        sys.exit(1)
+    client = make_artifact_client()
 
-    # Construct the parent path for listing Docker images
-    parent = f"projects/{project}/locations/{location}/repositories/{repo}"
+    parent = make_registry_parent(project, location, repository)
     docker_images = list_docker_images(client, parent)
 
     # we are fine deleting images without tags, with a single "-commit.", "-pr.", "-build.", "-debug." or "<commit-hash>"
@@ -164,17 +141,13 @@ async def main():
             img for img in old_images if img.uri.startswith(f"{registry}/{image}@")
         ]
         tagged_filtered_images = [img for img in filtered_images if len(img.tags) > 0]
-        untagged_filtered_images = [
-            img for img in filtered_images if len(img.tags) == 0
-        ]
+        untagged_filtered_images = [img for img in filtered_images if len(img.tags) == 0]
 
         print(f"Found {len(filtered_images)} old images for {image}")
         print(f"Found {len(tagged_filtered_images)} tagged images for {image}")
         print(f"Found {len(untagged_filtered_images)} untagged images for {image}")
-        for batch in itertools.batched(tagged_filtered_images, 20):
-            await delete_docker_images_list(batch, dry_run)
-        for batch in itertools.batched(untagged_filtered_images, 20):
-            await delete_docker_images_list(batch, dry_run)
+        await delete_in_batches(tagged_filtered_images, lambda img: delete_docker_image(img, dry_run))
+        await delete_in_batches(untagged_filtered_images, lambda img: delete_docker_image(img, dry_run))
 
 
 asyncio.run(main())

--- a/scripts/cleanup-docker-images.py
+++ b/scripts/cleanup-docker-images.py
@@ -93,7 +93,7 @@ async def delete_docker_image(img, dry_run):
 
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description="Cleanup old Docker images.")
-add_args(parser)
+add_args(parser, project_required=True)
 args = parser.parse_args()
 
 project = args.project

--- a/scripts/cleanup-docker-images.py
+++ b/scripts/cleanup-docker-images.py
@@ -141,13 +141,19 @@ async def main():
             img for img in old_images if img.uri.startswith(f"{registry}/{image}@")
         ]
         tagged_filtered_images = [img for img in filtered_images if len(img.tags) > 0]
-        untagged_filtered_images = [img for img in filtered_images if len(img.tags) == 0]
+        untagged_filtered_images = [
+            img for img in filtered_images if len(img.tags) == 0
+        ]
 
         print(f"Found {len(filtered_images)} old images for {image}")
         print(f"Found {len(tagged_filtered_images)} tagged images for {image}")
         print(f"Found {len(untagged_filtered_images)} untagged images for {image}")
-        await delete_in_batches(tagged_filtered_images, lambda img: delete_docker_image(img, dry_run))
-        await delete_in_batches(untagged_filtered_images, lambda img: delete_docker_image(img, dry_run))
+        await delete_in_batches(
+            tagged_filtered_images, lambda img: delete_docker_image(img, dry_run)
+        )
+        await delete_in_batches(
+            untagged_filtered_images, lambda img: delete_docker_image(img, dry_run)
+        )
 
 
 asyncio.run(main())

--- a/scripts/cleanup-npm-packages.py
+++ b/scripts/cleanup-npm-packages.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["google-cloud-artifact-registry==1.15.2","google-auth==2.38.0"]
+# ///
+
+"""
+cleanup-npm-packages.py
+
+This script cleans up old npm package versions from a Google Cloud Artifact Registry.
+It lists all packages in the specified repository, identifies versions older than
+a specified number of days whose version string contains "+commit" or "+pr", and
+deletes them. The script can also run in dry-run mode to simulate deletions without
+making any changes.
+
+Dependencies:
+- google-cloud-artifact-registry==1.15.2
+- google-auth==2.38.0
+
+Usage:
+    ./cleanup-npm-packages.py -p <project> [-l <location>] [-r <repository>] [-n] [-d <days>]
+
+Arguments:
+    -p, --project: The GCP project ID.
+    -l, --location: The region of the Artifact Registry (default: europe-west3).
+    -r, --repository: The Artifact repository name (default: npm).
+    -n, --dry-run: Simulate the deletion without making any changes.
+    -d, --days: Number of days to consider a version old (default: 60).
+
+Example:
+    ./cleanup-npm-packages.py -p my-project -l europe-west3 -r npm -d 30 --dry-run
+"""
+
+import importlib.util
+import os
+
+_spec = importlib.util.spec_from_file_location(
+    "cleanup_common",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "cleanup-common.py"),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+add_args = _mod.add_args
+make_cutoff_date = _mod.make_cutoff_date
+make_artifact_client = _mod.make_artifact_client
+make_registry_parent = _mod.make_registry_parent
+delete_in_batches = _mod.delete_in_batches
+
+from datetime import UTC
+from urllib.parse import unquote
+from google.cloud import artifactregistry_v1
+import argparse
+import asyncio
+import re
+import sys
+
+
+def list_packages(client, parent):
+    """Lists packages in an Artifact Registry npm repository."""
+    try:
+        print(f"Listing packages in {parent}")
+        request = artifactregistry_v1.ListPackagesRequest(parent=parent)
+        return list(client.list_packages(request=request))
+    except Exception as e:
+        print(f"Error listing packages: {str(e)}", file=sys.stderr)
+        sys.exit(1)
+
+
+def list_versions(client, parent):
+    """Lists versions of a package in Artifact Registry."""
+    try:
+        # FULL view is required to populate create_time; the default view returns only the name
+        request = artifactregistry_v1.ListVersionsRequest(
+            parent=parent,
+            view=artifactregistry_v1.VersionView.FULL,
+        )
+        return list(client.list_versions(request=request))
+    except Exception as e:
+        print(f"Error listing versions for {parent}: {str(e)}", file=sys.stderr)
+        return []
+
+
+async def delete_old_version(client, version, dry_run):
+    """Deletes a package version by its resource name."""
+    parts = version.name.split("/")
+    package = unquote(parts[-3]) if len(parts) >= 3 else "unknown"
+    ver = unquote(parts[-1]) if parts else "unknown"
+
+    if dry_run:
+        print(f"Dry-run mode: Would delete npm package '{package}' version '{ver}'")
+        return
+    try:
+        print(f"Deleting npm package '{package}' version '{ver}'")
+        request = artifactregistry_v1.DeleteVersionRequest(name=version.name)
+        client.delete_version(request=request)
+    except Exception as e:
+        print(f"Error deleting version '{ver}' of '{package}': {str(e)}", file=sys.stderr)
+
+
+# Parse command-line arguments
+parser = argparse.ArgumentParser(description="Cleanup old npm package versions.")
+add_args(parser, repository_default="npm", project_required=True)
+args = parser.parse_args()
+
+project = args.project
+location = args.location
+repository = args.repository
+dry_run = args.dry_run
+date = make_cutoff_date(args.days)
+
+# Match versions containing -commit./-pr. (current format) or +commit./+pr. (future semver format)
+version_filter = re.compile(r"[-+](commit|pr)\.")
+
+
+async def main():
+    """Main function to clean up old npm package versions."""
+    client = make_artifact_client()
+
+    parent = make_registry_parent(project, location, repository)
+    packages = list_packages(client, parent)
+    print(f"Found {len(packages)} packages")
+
+    for package in packages:
+        versions = list_versions(client, package.name)
+        package_name = unquote(package.name.split("/")[-1])
+        # Debug: uncomment to inspect the first 5 versions per package
+        # print(f"  Package '{package_name}': {len(versions)} versions total")
+        # for v in versions[:5]:
+        #     ver_str = unquote(v.name.split("/")[-1])
+        #     create_dt = v.create_time.timestamp_pb().ToDatetime().astimezone(UTC)
+        #     tags = [t.name.split("/")[-1] for t in v.related_tags]
+        #     age_ok = create_dt < date
+        #     pattern_ok = bool(version_filter.search(ver_str))
+        #     print(f"    ver='{ver_str}' create={create_dt.date()} age_ok={age_ok} pattern_ok={pattern_ok} tags={tags}")
+        old_versions = [
+            version
+            for version in versions
+            if version.create_time.timestamp_pb().ToDatetime().astimezone(UTC) < date
+            and version_filter.search(unquote(version.name.split("/")[-1]))
+            and not version.related_tags
+        ]
+        print(f"Found {len(old_versions)} old versions for '{package_name}'")
+        await delete_in_batches(old_versions, lambda version: delete_old_version(client, version, dry_run))
+
+
+asyncio.run(main())

--- a/scripts/cleanup-npm-packages.py
+++ b/scripts/cleanup-npm-packages.py
@@ -93,7 +93,9 @@ async def delete_old_version(client, version, dry_run):
         request = artifactregistry_v1.DeleteVersionRequest(name=version.name)
         client.delete_version(request=request)
     except Exception as e:
-        print(f"Error deleting version '{ver}' of '{package}': {str(e)}", file=sys.stderr)
+        print(
+            f"Error deleting version '{ver}' of '{package}': {str(e)}", file=sys.stderr
+        )
 
 
 # Parse command-line arguments
@@ -139,7 +141,9 @@ async def main():
             and not version.related_tags
         ]
         print(f"Found {len(old_versions)} old versions for '{package_name}'")
-        await delete_in_batches(old_versions, lambda version: delete_old_version(client, version, dry_run))
+        await delete_in_batches(
+            old_versions, lambda version: delete_old_version(client, version, dry_run)
+        )
 
 
 asyncio.run(main())

--- a/scripts/cleanup-npm-packages.py
+++ b/scripts/cleanup-npm-packages.py
@@ -8,7 +8,7 @@ cleanup-npm-packages.py
 
 This script cleans up old npm package versions from a Google Cloud Artifact Registry.
 It lists all packages in the specified repository, identifies versions older than
-a specified number of days whose version string contains "+commit" or "+pr", and
+a specified number of days whose version string contains "-commit" or "-pr", and
 deletes them. The script can also run in dry-run mode to simulate deletions without
 making any changes.
 
@@ -107,8 +107,8 @@ repository = args.repository
 dry_run = args.dry_run
 date = make_cutoff_date(args.days)
 
-# Match versions containing -commit./-pr. (current format) or +commit./+pr. (future semver format)
-version_filter = re.compile(r"[-+](commit|pr)\.")
+# Match versions containing -commit./-pr. (current format)
+version_filter = re.compile(r"-(commit|pr)\.")
 
 
 async def main():


### PR DESCRIPTION
Adds a cleanup task to remove old npm packages older than 60 days

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NPM package cleanup to automated cleanup workflows.

* **Chores**
  * Updated Docker cleanup workflow to use explicit registry/project/location parameters.
  * Centralized cleanup helpers across scripts for consistent argument handling, cutoff calculation, and batched deletions.
  * Added a runnable app wrapper for the NPM cleanup and adjusted the release/version action to vary semver delimiter by input file type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->