### PR TITLE
fix: Fixes ambiguity on packages

### DIFF
--- a/actions/set-build-version/action.yaml
+++ b/actions/set-build-version/action.yaml
@@ -186,7 +186,7 @@ runs:
           if [[ "${{ inputs.file }}" =~ .*Cargo\.toml$ ]]; then
             echo "Regenerating lock file"
             nix develop --command bash -c "cargo metadata --no-deps --format-version 1 --manifest-path ${{ inputs.file }} \
-              | jq -r '.packages[] | select(.source == null) | .name' \
+              | jq -r '.packages[] | select(.source == null) | "\(.name)@\(.version)"' \
               | xargs -I{} cargo update --manifest-path ${{ inputs.file }} -p {}"
           fi
         elif [[ "${{ inputs.file }}" =~ ^.*\.json$ ]]; then


### PR DESCRIPTION
Some workflow runs fail https://github.com/hoprnet/blokli/actions/runs/25452412536/job/74672872066
because it found ambiguity while updating packages references in Cargo.lock file when bumping or renaming the version

The jq outputs only the package name, so when there are two versions of blokli-client in the lock (0.18.1 from git via hopr-chain-connector, 0.19.0 as workspace member), cargo update -p blokli-client is ambiguous

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build version processing pipeline to include version identifiers with package names during build updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->