### PR TITLE
feat: Migrate runners to depot.dev

### DIFF
--- a/.github/workflows/benchmarks.md
+++ b/.github/workflows/benchmarks.md
@@ -19,7 +19,7 @@ jobs:
       contents: read
       checks: write
       pull-requests: write
-    uses: hoprnet/hopr-workflows/.github/workflows/benchmarks.yaml@<commit-hash>
+    uses: hoprnet/hopr-workflows/.github/workflows/benchmarks.yaml@workflow-benchmarks-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
       runner: depot-ubuntu-22.04-4

--- a/.github/workflows/benchmarks.md
+++ b/.github/workflows/benchmarks.md
@@ -22,7 +22,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/benchmarks.yaml@<commit-hash>
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-22.04-4
       bencher_project: ${{ github.event.repository.name }}
       should_build: true
       should_run: true

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -8,6 +8,7 @@ on:
       runner:
         required: true
         type: string
+        default: depot-ubuntu-22.04-4
       bencher_project:
         required: true
         type: string

--- a/.github/workflows/build-binaries.md
+++ b/.github/workflows/build-binaries.md
@@ -24,7 +24,7 @@ jobs:
       cachix_cache_name: hopr
       build_command: nix build .#binary-hoprd-x86_64-linux
       binary: hoprd
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-22.04-4
     secrets:
       gcp_service_account: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -51,8 +51,9 @@ on:
         default: 60
         description: "Timeout for the job in minutes"
       runner:
-        required: true
+        required: false
         type: string
+        default: depot-ubuntu-22.04-4
       enabled:
         required: false
         type: boolean

--- a/.github/workflows/build-docker.md
+++ b/.github/workflows/build-docker.md
@@ -30,7 +30,7 @@ jobs:
       build_matrix: >-
         [
           {
-            "runner": "self-hosted-hoprnet-bigger",
+            "runner": "depot-ubuntu-22.04-4",
             "architecture": "x86_64-linux",
             "build_command": "nix run -L .#docker-hoprd-x86_64-linux",
             "smoke_test_command": "nix develop -c just smoke-test"

--- a/.github/workflows/build-library.md
+++ b/.github/workflows/build-library.md
@@ -14,7 +14,7 @@ jobs:
       package_name: my-crate
       architecture: x86_64-linux
       cachix_cache_name: hopr
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-22.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       cargo_registry_token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -33,8 +33,9 @@ on:
         default: 60
         description: "Timeout for the job in minutes"
       runner:
-        required: true
+        required: false
         type: string
+        default: depot-ubuntu-22.04-4
       enabled:
         required: false
         type: boolean

--- a/.github/workflows/checks-zizmor.md
+++ b/.github/workflows/checks-zizmor.md
@@ -13,7 +13,7 @@ jobs:
       security-events: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-22.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 ```
@@ -23,7 +23,7 @@ jobs:
 | Name             | Required | Default                                                                    | Description                |
 | ---------------- | -------- | -------------------------------------------------------------------------- | -------------------------- |
 | `source_branch`  | Yes      | —                                                                          | Source branch to check out |
-| `runner`         | No       | `ubuntu-latest`                                                            | Runner for the job         |
+| `runner`         | No       | `depot-ubuntu-22.04`                                                            | Runner for the job         |
 | `zizmor_command` | No       | `nix develop -L .#ci -c bash -c "zizmor --format sarif . > results.sarif"` | Command to run zizmor      |
 
 ## Secrets

--- a/.github/workflows/checks-zizmor.md
+++ b/.github/workflows/checks-zizmor.md
@@ -23,7 +23,7 @@ jobs:
 | Name             | Required | Default                                                                    | Description                |
 | ---------------- | -------- | -------------------------------------------------------------------------- | -------------------------- |
 | `source_branch`  | Yes      | —                                                                          | Source branch to check out |
-| `runner`         | No       | `depot-ubuntu-22.04`                                                            | Runner for the job         |
+| `runner`         | No       | `depot-ubuntu-22.04`                                                       | Runner for the job         |
 | `zizmor_command` | No       | `nix develop -L .#ci -c bash -c "zizmor --format sarif . > results.sarif"` | Command to run zizmor      |
 
 ## Secrets

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -18,7 +18,7 @@ on:
       runner:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "depot-ubuntu-22.04"
       zizmor_command:
         required: false
         type: string

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -18,7 +18,7 @@ on:
       runner:
         required: false
         type: string
-        default: "depot-ubuntu-22.04"
+        default: depot-ubuntu-22.04
       zizmor_command:
         required: false
         type: string

--- a/.github/workflows/checks.md
+++ b/.github/workflows/checks.md
@@ -11,8 +11,8 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@workflow-checks-v1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      runner_small: self-hosted-hoprnet-small
-      runner_large: self-hosted-hoprnet-bigger
+      runner_small: depot-ubuntu-22.04
+      runner_large: depot-ubuntu-22.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 ```
@@ -30,8 +30,8 @@ jobs:
 | `lint_command`       | No       | `nix run -L .#check`                                         | Command for linting                         |
 | `deps_command`       | No       | `nix develop .#ci -c bash -c "cargo machete && cargo shear"` | Command for dependency check                |
 | `audit_command`      | No       | `nix run .#audit`                                            | Command for security audit                  |
-| `runner_small`       | No       | `ubuntu-latest`                                              | Runner for lightweight checks (pre-commit)  |
-| `runner_large`       | No       | `ubuntu-latest`                                              | Runner for heavy checks (lint, deps, audit) |
+| `runner_small`       | No       | `depot-ubuntu-22.04`                                              | Runner for lightweight checks (pre-commit)  |
+| `runner_large`       | No       | `depot-ubuntu-22.04`                                              | Runner for heavy checks (lint, deps, audit) |
 | `disable_sudo`       | No       | `true`                                                       | Disable sudo in harden-runner               |
 
 ## Secrets

--- a/.github/workflows/checks.md
+++ b/.github/workflows/checks.md
@@ -30,8 +30,8 @@ jobs:
 | `lint_command`       | No       | `nix run -L .#check`                                         | Command for linting                         |
 | `deps_command`       | No       | `nix develop .#ci -c bash -c "cargo machete && cargo shear"` | Command for dependency check                |
 | `audit_command`      | No       | `nix run .#audit`                                            | Command for security audit                  |
-| `runner_small`       | No       | `depot-ubuntu-22.04`                                              | Runner for lightweight checks (pre-commit)  |
-| `runner_large`       | No       | `depot-ubuntu-22.04-4`                                              | Runner for heavy checks (lint, deps, audit) |
+| `runner_small`       | No       | `depot-ubuntu-22.04`                                         | Runner for lightweight checks (pre-commit)  |
+| `runner_large`       | No       | `depot-ubuntu-22.04-4`                                       | Runner for heavy checks (lint, deps, audit) |
 | `disable_sudo`       | No       | `true`                                                       | Disable sudo in harden-runner               |
 
 ## Secrets

--- a/.github/workflows/checks.md
+++ b/.github/workflows/checks.md
@@ -31,7 +31,7 @@ jobs:
 | `deps_command`       | No       | `nix develop .#ci -c bash -c "cargo machete && cargo shear"` | Command for dependency check                |
 | `audit_command`      | No       | `nix run .#audit`                                            | Command for security audit                  |
 | `runner_small`       | No       | `depot-ubuntu-22.04`                                              | Runner for lightweight checks (pre-commit)  |
-| `runner_large`       | No       | `depot-ubuntu-22.04`                                              | Runner for heavy checks (lint, deps, audit) |
+| `runner_large`       | No       | `depot-ubuntu-22.04-4`                                              | Runner for heavy checks (lint, deps, audit) |
 | `disable_sudo`       | No       | `true`                                                       | Disable sudo in harden-runner               |
 
 ## Secrets

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -47,11 +47,11 @@ on:
       runner_small:
         required: false
         type: string
-        default: "depot-ubuntu-22.04"
+        default: depot-ubuntu-22.04
       runner_large:
         required: false
         type: string
-        default: "depot-ubuntu-22.04"
+        default: depot-ubuntu-22.04-4
       disable_sudo:
         required: false
         type: boolean

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -47,11 +47,11 @@ on:
       runner_small:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "depot-ubuntu-22.04"
       runner_large:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "depot-ubuntu-22.04"
       disable_sudo:
         required: false
         type: boolean

--- a/.github/workflows/cleanup-registry.yaml
+++ b/.github/workflows/cleanup-registry.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   cleanup-registry:
     name: Cleanup Registry
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Harden Runner

--- a/.github/workflows/tests.md
+++ b/.github/workflows/tests.md
@@ -59,7 +59,7 @@ jobs:
 | `benchmark_command`            | No       | `nix build .#bench-build`         | Command for benchmarks                                                          |
 | `unit_coverage_command`        | No       | `nix run .#coverage-unit`         | Command for unit coverage                                                       |
 | `integration_coverage_command` | No       | `nix run .#coverage-integration`  | Command for integration coverage                                                |
-| `runner_unit`                  | No       | `ubuntu-latest`                   | Runner for unit tests, nightly tests, benchmarks, and unit coverage             |
+| `runner_unit`                  | No       | `depot-ubuntu-22.04`                   | Runner for unit tests, nightly tests, benchmarks, and unit coverage             |
 | `runner_integration`           | No       | `""`                              | Runner for integration tests and coverage. Falls back to `runner_unit` if empty |
 | `test_timeout`                 | No       | `60`                              | Timeout in minutes for test jobs                                                |
 | `benchmark_timeout`            | No       | `20`                              | Timeout in minutes for benchmark job                                            |

--- a/.github/workflows/tests.md
+++ b/.github/workflows/tests.md
@@ -59,7 +59,7 @@ jobs:
 | `benchmark_command`            | No       | `nix build .#bench-build`         | Command for benchmarks                                                          |
 | `unit_coverage_command`        | No       | `nix run .#coverage-unit`         | Command for unit coverage                                                       |
 | `integration_coverage_command` | No       | `nix run .#coverage-integration`  | Command for integration coverage                                                |
-| `runner_unit`                  | No       | `depot-ubuntu-22.04`                   | Runner for unit tests, nightly tests, benchmarks, and unit coverage             |
+| `runner_unit`                  | No       | `depot-ubuntu-22.04`              | Runner for unit tests, nightly tests, benchmarks, and unit coverage             |
 | `runner_integration`           | No       | `""`                              | Runner for integration tests and coverage. Falls back to `runner_unit` if empty |
 | `test_timeout`                 | No       | `60`                              | Timeout in minutes for test jobs                                                |
 | `benchmark_timeout`            | No       | `20`                              | Timeout in minutes for benchmark job                                            |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,7 +66,7 @@ on:
       runner_unit:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "depot-ubuntu-22.04"
         description: >-
           Runner for unit tests, nightly tests, benchmarks, and unit coverage.
       runner_integration:

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ This repository contains a collection of custom GitHub Actions and Reusable Work
 - [Checks](./.github/workflows/checks.md): Runs configurable code-quality checks (pre-commit, lint, deps, audit) via a matrix strategy.
 - [Checks Zizmor](./.github/workflows/checks-zizmor.md): Scans GitHub Actions workflow files for security issues using zizmor and uploads SARIF to the GitHub Security tab.
 - [Tests](./.github/workflows/tests.md): Runs configurable test suites (unit, integration, nightly), benchmarks, and coverage reports.
+
+## Tags
+
+The reusable workflows and actions use the following tagging pattern:
+- `<action-name>-v<major_version_number>` 
+- `<workflow-name>-v<major_version_number>`

--- a/README.md
+++ b/README.md
@@ -31,5 +31,6 @@ This repository contains a collection of custom GitHub Actions and Reusable Work
 ## Tags
 
 The reusable workflows and actions use the following tagging pattern:
-- `<action-name>-v<major_version_number>` 
+
+- `<action-name>-v<major_version_number>`
 - `<workflow-name>-v<major_version_number>`

--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -113,7 +113,7 @@ runs:
         else
           echo "commit_files=${{ inputs.file }}" | tee -a "$GITHUB_OUTPUT"
         fi
-    - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+    - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
       with:
         add: '${{ steps.versions.outputs.commit_files }}'
         new_branch: ${{ github.ref_name }}


### PR DESCRIPTION
The affected workflows are:
- workflow-benchmarks-v2
- build-library-v2
- workflow-checks-zizmor-v1
- workflow-checks-v1
- workflow-tests-v4
- bump-version-v2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow runner configurations across multiple CI/CD pipelines for optimized infrastructure utilization
  * Updated action dependency to a newer version

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoprnet/hopr-workflows/pull/67)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->