### PR TITLE
fix(build-docker): bypass v1 registries.conf for skopeo >=1.23

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -180,6 +180,8 @@ jobs:
       - name: Publish docker image - ${{ inputs.docker_image_name }}:${{ steps.version.outputs.docker_build_version_platform }}
         run: |
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
+            mkdir -p "$HOME/.config/containers"
+            printf 'unqualified-search-registries = ["docker.io"]\n' > "$HOME/.config/containers/registries.conf"
             set -euo pipefail
             base_branch=${{ github.event.pull_request.base.ref }}
             publish_image() {
@@ -236,6 +238,8 @@ jobs:
         if: steps.version.outputs.docker_debug_version_platform != '' && matrix.build_debug_command != ''
         run: |
           nix shell nixpkgs#skopeo -c bash << 'SKOPEO'
+            mkdir -p "$HOME/.config/containers"
+            printf 'unqualified-search-registries = ["docker.io"]\n' > "$HOME/.config/containers/registries.conf"
             set -euo pipefail
             echo "Publishing image ${GCP_DEBUG_IMAGE_NAME}"
             if [[ "${{ inputs.docker_image_format }}" == "skopeo" ]]; then


### PR DESCRIPTION
## Summary

- skopeo ≥1.23 (reached via the floating `nixpkgs#skopeo` pin around 2026-05-27) rejects `/etc/containers/registries.conf` that is in v1 format on depot runners, aborting with `registries.conf must be in v2 format but is in v1` before any image I/O.
- Fix: write a minimal v2 `registries.conf` to `$HOME/.config/containers/registries.conf` inside both skopeo heredocs before `set -euo pipefail`. The `containers/image` library prefers user-level config over `/etc`, so the system file is bypassed without touching runner state.
- Affects both the main publish block (L180) and the debug publish block (L238).

**Observed failure** on hoprd PR #47, run [26682412398](https://github.com/hoprnet/hoprd/actions/runs/26682412398):
```
Publishing image europe-west3-docker.pkg.dev/hoprassociation/docker-images/hoprd:4.0.3-rc.4-commit.bc58192-linux-amd64
fatal: ...loading registries configuration "/etc/containers/registries.conf": registries.conf must be in v2 format but is in v1
```
Same error on every hoprd PR since 2026-05-29 (hoprd #46, others). hoprd PRs `#41` and earlier succeeded with skopeo 1.20.0.

**After merge**, force-move the `build-docker-v2` tag to this commit so all consumers pick up the fix automatically:
```
git push origin :refs/tags/build-docker-v2
git tag -f build-docker-v2 <merged-sha>
git push origin refs/tags/build-docker-v2
```
No consumer repo changes required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image publishing workflow configuration to improve the build pipeline execution environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->