### PR TITLE
feat(checks): add Format matrix entry with nix fmt --ci default

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,7 +1,7 @@
 ################################################################################
 # Reusable check pipeline
 #
-# Runs configurable code-quality checks (pre-commit, lint, deps, audit)
+# Runs configurable code-quality checks (format, pre-commit, lint, deps, audit)
 # via a matrix strategy with per-check enable/disable toggles and command
 # overrides.
 ################################################################################
@@ -16,6 +16,14 @@ on:
         required: false
         type: boolean
         default: true
+      format:
+        required: false
+        type: boolean
+        default: false
+      format_command:
+        required: false
+        type: string
+        default: "nix fmt -- --ci"
       lint:
         required: false
         type: boolean
@@ -76,6 +84,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: Format
+            enabled: ${{ inputs.format }}
+            runner: ${{ inputs.runner_small }}
+            timeout: 10
+            command: ${{ inputs.format_command }}
           - name: Pre-commit
             enabled: ${{ inputs.pre_commit }}
             runner: ${{ inputs.runner_small }}


### PR DESCRIPTION
## Summary

- Adds a `format` boolean input (default `false`) and a `format_command` string input (default `nix fmt -- --ci`) to the reusable `checks.yaml` workflow
- Adds a `Format` matrix entry as the **first** step so cheap formatting failures surface before heavier Lint/Clippy jobs
- Purely additive — existing callers with no `format:` input continue unchanged under `workflow-checks-v1`

## Why

`nix fmt` was enforced in a workaround pattern: some repos (edge-client, edge-client-aes-hw) added a separate invocation of this reusable workflow with `lint_command: "nix fmt && git diff --exit-code"` and `disable_sudo: false`. Other repos (hoprnet, hopli, hopr-api, hopr-types, blokli) had no format enforcement at all. This PR makes format a first-class, opt-in check so all repos can adopt it cleanly.

## Consumer PRs

After this merges and the `workflow-checks-v1` tag advances to the new SHA, each consumer repo will open a follow-up PR to:
1. Remove any existing standalone format workaround job
2. Add `format: true` to their existing `checks:` invocation
3. Bump the pinned SHA

Repos in scope: `edge-client`, `edge-client-aes-hw`, `hoprnet`, `hopli`, `hopr-api`, `hopr-types`, `blokli`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow with an optional format validation check and configurable format command parameters for improved code quality assurance in development pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->