### PR TITLE
fix: use caller's dev-shell

### DIFF
--- a/.github/workflows/build-library.md
+++ b/.github/workflows/build-library.md
@@ -2,6 +2,8 @@
 
 Builds a Rust library for a specific architecture using Nix and publishes it to crates.io. On non-release builds (`version_type != release`) a dry-run is executed to validate the publish without actually uploading. On release builds the crate is published to crates.io with `cargo release publish --execute`.
 
+The workflow assumes the caller repository's default development shell already provides `cargo release`, so the publish step runs through a single `nix develop` invocation with no nested `nix shell`.
+
 ## Usage
 
 ```yaml
@@ -48,5 +50,5 @@ jobs:
 2. **Checkout repository** — checks out `source_branch`
 3. **Setup Nix** — configures the Nix environment with Cachix
 4. **Updates build version** — stamps the version using [set-build-version](../actions/set-build-version/README.md)
-5. **Build dry-run library** _(non-release only)_ — runs `cargo release publish --all-features` without `--execute` to validate the package
-6. **Publish library** _(release only)_ — runs `cargo release publish --execute --all-features --no-confirm`
+5. **Build dry-run library** _(non-release only)_ — runs `cargo release publish --all-features` without `--execute` to validate the package through the caller's default dev shell
+6. **Publish library** _(release only)_ — runs `cargo release publish --execute --all-features --no-confirm` through the caller's default dev shell

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Build dry-run library
         if: inputs.version_type != 'release'
         shell: bash
-        run: nix develop -c nix shell nixpkgs#cargo-release -c cargo release publish $CONTEXT --all-features
+        run: nix develop -c cargo release publish $CONTEXT --all-features
         env:
           CONTEXT: ${{ inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
       - name: Publish library
@@ -98,4 +98,4 @@ jobs:
             echo "::error::secrets.cargo_registry_token is required when version_type='release'"
             exit 1
           fi
-          nix develop -c nix shell nixpkgs#cargo-release -c cargo release publish $CONTEXT --execute --all-features --no-confirm
+          nix develop -c cargo release publish $CONTEXT --execute --all-features --no-confirm


### PR DESCRIPTION
Avoids the nested `nix` pattern, as it was failing in some CI library builds.
The workflow now assumes that `cargo-release` is available in the caller's devshell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal build and release workflow processes by simplifying the development environment invocation, reducing unnecessary nesting while maintaining all existing release flags and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->