### PR TITLE
feat(build-library): add optional targets input for cargo verification

### DIFF
--- a/.github/workflows/build-library.md
+++ b/.github/workflows/build-library.md
@@ -35,13 +35,6 @@ To verify (or publish) against explicit Rust target triples instead of the runne
         aarch64-unknown-linux-gnu
 ```
 
-`package_name` also accepts `--workspace` directly to make the workspace selection explicit:
-
-```yaml
-    with:
-      package_name: "--workspace"
-      targets: "x86_64-unknown-linux-gnu"
-```
 
 ## Inputs
 
@@ -49,7 +42,7 @@ To verify (or publish) against explicit Rust target triples instead of the runne
 | ------------------- | -------- | ----------------------------- | ---------------------------------------------------------------------------------------- |
 | `source_branch`     | Yes      | —                             | Source branch to build from                                                              |
 | `version_type`      | Yes      | —                             | Versioning strategy: `commit`, `pr`, or `release`. Only `release` publishes to crates.io |
-| `package_name`      | Yes      | —                             | Crate name to publish (e.g. `hopr-types`). Pass `--workspace` to publish all workspace crates. |
+| `package_name`      | Yes      | —                             | Crate name to publish (e.g. `hopr-types`). When empty, defaults to `--workspace`.              |
 | `architecture`      | Yes      | —                             | Target architecture (e.g. `x86_64-linux`)                                                |
 | `cachix_cache_name` | No       | —                             | Cachix cache name                                                                        |
 | `nix_path`          | No       | `nixpkgs=channel:nixos-26.05` | Nix path to use                                                                          |

--- a/.github/workflows/build-library.md
+++ b/.github/workflows/build-library.md
@@ -9,7 +9,7 @@ The workflow assumes the caller repository's default development shell already p
 ```yaml
 jobs:
   build-library:
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v3
     with:
       source_branch: ${{ github.ref_name }}
       version_type: release
@@ -19,7 +19,13 @@ jobs:
       runner: depot-ubuntu-22.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      cargo_registry_token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+```
+
+To verify (or publish) against explicit Rust target triples instead of the runner's host default, supply `targets`:
+
+```yaml
+    with:
+      targets: "x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
 ```
 
 ## Inputs
@@ -36,13 +42,13 @@ jobs:
 | `timeout_minutes`   | No       | `60`                          | Timeout in minutes                                                                       |
 | `runner`            | Yes      | —                             | Runner label for the job                                                                 |
 | `enabled`           | No       | `true`                        | Whether to run this job                                                                  |
+| `targets`           | No       | `""`                          | Space-separated Rust target triples passed as repeated `--target` flags to `cargo release publish`. Empty (default) verifies against the host triple only. |
 
 ## Secrets
 
-| Name                   | Required | Description                                                    |
-| ---------------------- | -------- | -------------------------------------------------------------- |
-| `cachix_auth_token`    | Yes      | Auth token for Cachix cache                                    |
-| `cargo_registry_token` | No       | crates.io API token. Required when `version_type` is `release` |
+| Name                | Required | Description                                               |
+| ------------------- | -------- | --------------------------------------------------------- |
+| `cachix_auth_token` | Yes      | Auth token for Cachix cache                               |
 
 ## Steps
 

--- a/.github/workflows/build-library.md
+++ b/.github/workflows/build-library.md
@@ -24,39 +24,38 @@ jobs:
 To verify (or publish) against explicit Rust target triples instead of the runner's host default, supply `targets`. GitHub Actions `workflow_call` inputs have no list type, so use either a space-separated inline string or a YAML block scalar — both work:
 
 ```yaml
-    with:
-      targets: "x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
+with:
+  targets: "x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
 ```
 
 ```yaml
-    with:
-      targets: |
-        x86_64-unknown-linux-gnu
-        aarch64-unknown-linux-gnu
+with:
+  targets: |
+    x86_64-unknown-linux-gnu
+    aarch64-unknown-linux-gnu
 ```
-
 
 ## Inputs
 
-| Name                | Required | Default                       | Description                                                                              |
-| ------------------- | -------- | ----------------------------- | ---------------------------------------------------------------------------------------- |
-| `source_branch`     | Yes      | —                             | Source branch to build from                                                              |
-| `version_type`      | Yes      | —                             | Versioning strategy: `commit`, `pr`, or `release`. Only `release` publishes to crates.io |
-| `package_name`      | No       | —                             | Crate name to publish (e.g. `hopr-types`). When empty, defaults to `--workspace`.              |
-| `architecture`      | Yes      | —                             | Target architecture (e.g. `x86_64-linux`)                                                |
-| `cachix_cache_name` | No       | —                             | Cachix cache name                                                                        |
-| `nix_path`          | No       | `nixpkgs=channel:nixos-26.05` | Nix path to use                                                                          |
-| `build_file`        | No       | `Cargo.toml`                  | File to extract version from                                                             |
-| `timeout_minutes`   | No       | `60`                          | Timeout in minutes                                                                       |
-| `runner`            | Yes      | —                             | Runner label for the job                                                                 |
-| `enabled`           | No       | `true`                        | Whether to run this job                                                                  |
-| `targets`           | No       | `""`                          | Rust target triples passed as repeated `--target` flags to `cargo release publish`. Accepts a space-separated string or a YAML block scalar (`|`). Empty (default) verifies against the host triple only. |
+| Name                | Required | Default                       | Description                                                                                                                                                                                         |
+| ------------------- | -------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source_branch`     | Yes      | —                             | Source branch to build from                                                                                                                                                                         |
+| `version_type`      | Yes      | —                             | Versioning strategy: `commit`, `pr`, or `release`. Only `release` publishes to crates.io                                                                                                            |
+| `package_name`      | No       | —                             | Crate name to publish (e.g. `hopr-types`). When empty, defaults to `--workspace`.                                                                                                                   |
+| `architecture`      | Yes      | —                             | Target architecture (e.g. `x86_64-linux`)                                                                                                                                                           |
+| `cachix_cache_name` | No       | —                             | Cachix cache name                                                                                                                                                                                   |
+| `nix_path`          | No       | `nixpkgs=channel:nixos-26.05` | Nix path to use                                                                                                                                                                                     |
+| `build_file`        | No       | `Cargo.toml`                  | File to extract version from                                                                                                                                                                        |
+| `timeout_minutes`   | No       | `60`                          | Timeout in minutes                                                                                                                                                                                  |
+| `runner`            | Yes      | —                             | Runner label for the job                                                                                                                                                                            |
+| `enabled`           | No       | `true`                        | Whether to run this job                                                                                                                                                                             |
+| `targets`           | No       | `""`                          | Rust target triples passed as repeated `--target` flags to `cargo release publish`. Accepts a space-separated string or a YAML block scalar. Empty (default) verifies against the host triple only. |
 
 ## Secrets
 
-| Name                | Required | Description                                               |
-| ------------------- | -------- | --------------------------------------------------------- |
-| `cachix_auth_token` | Yes      | Auth token for Cachix cache                               |
+| Name                | Required | Description                 |
+| ------------------- | -------- | --------------------------- |
+| `cachix_auth_token` | Yes      | Auth token for Cachix cache |
 
 ## Steps
 

--- a/.github/workflows/build-library.md
+++ b/.github/workflows/build-library.md
@@ -28,6 +28,13 @@ To verify (or publish) against explicit Rust target triples instead of the runne
       targets: "x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
 ```
 
+`--workspace` is also accepted as a token inside `targets`. When present it overrides the `package_name` → `--package`/`--workspace` selection:
+
+```yaml
+    with:
+      targets: "--workspace x86_64-unknown-linux-gnu"
+```
+
 ## Inputs
 
 | Name                | Required | Default                       | Description                                                                              |
@@ -42,7 +49,7 @@ To verify (or publish) against explicit Rust target triples instead of the runne
 | `timeout_minutes`   | No       | `60`                          | Timeout in minutes                                                                       |
 | `runner`            | Yes      | —                             | Runner label for the job                                                                 |
 | `enabled`           | No       | `true`                        | Whether to run this job                                                                  |
-| `targets`           | No       | `""`                          | Space-separated Rust target triples passed as repeated `--target` flags to `cargo release publish`. Empty (default) verifies against the host triple only. |
+| `targets`           | No       | `""`                          | Space-separated tokens: Rust target triples become `--target <triple>`; the special token `--workspace` overrides `package_name` and selects the whole workspace. Empty (default) behaves as before. |
 
 ## Secrets
 

--- a/.github/workflows/build-library.md
+++ b/.github/workflows/build-library.md
@@ -28,11 +28,12 @@ To verify (or publish) against explicit Rust target triples instead of the runne
       targets: "x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
 ```
 
-`--workspace` is also accepted as a token inside `targets`. When present it overrides the `package_name` → `--package`/`--workspace` selection:
+`package_name` also accepts `--workspace` directly to make the workspace selection explicit:
 
 ```yaml
     with:
-      targets: "--workspace x86_64-unknown-linux-gnu"
+      package_name: "--workspace"
+      targets: "x86_64-unknown-linux-gnu"
 ```
 
 ## Inputs
@@ -41,7 +42,7 @@ To verify (or publish) against explicit Rust target triples instead of the runne
 | ------------------- | -------- | ----------------------------- | ---------------------------------------------------------------------------------------- |
 | `source_branch`     | Yes      | —                             | Source branch to build from                                                              |
 | `version_type`      | Yes      | —                             | Versioning strategy: `commit`, `pr`, or `release`. Only `release` publishes to crates.io |
-| `package_name`      | Yes      | —                             | Crate name to publish (e.g. `hopr-types`)                                                |
+| `package_name`      | Yes      | —                             | Crate name to publish (e.g. `hopr-types`). Pass `--workspace` to publish all workspace crates. |
 | `architecture`      | Yes      | —                             | Target architecture (e.g. `x86_64-linux`)                                                |
 | `cachix_cache_name` | No       | —                             | Cachix cache name                                                                        |
 | `nix_path`          | No       | `nixpkgs=channel:nixos-26.05` | Nix path to use                                                                          |
@@ -49,7 +50,7 @@ To verify (or publish) against explicit Rust target triples instead of the runne
 | `timeout_minutes`   | No       | `60`                          | Timeout in minutes                                                                       |
 | `runner`            | Yes      | —                             | Runner label for the job                                                                 |
 | `enabled`           | No       | `true`                        | Whether to run this job                                                                  |
-| `targets`           | No       | `""`                          | Space-separated tokens: Rust target triples become `--target <triple>`; the special token `--workspace` overrides `package_name` and selects the whole workspace. Empty (default) behaves as before. |
+| `targets`           | No       | `""`                          | Space-separated Rust target triples passed as repeated `--target` flags to `cargo release publish`. Empty (default) verifies against the host triple only. |
 
 ## Secrets
 

--- a/.github/workflows/build-library.md
+++ b/.github/workflows/build-library.md
@@ -42,7 +42,7 @@ To verify (or publish) against explicit Rust target triples instead of the runne
 | ------------------- | -------- | ----------------------------- | ---------------------------------------------------------------------------------------- |
 | `source_branch`     | Yes      | —                             | Source branch to build from                                                              |
 | `version_type`      | Yes      | —                             | Versioning strategy: `commit`, `pr`, or `release`. Only `release` publishes to crates.io |
-| `package_name`      | Yes      | —                             | Crate name to publish (e.g. `hopr-types`). When empty, defaults to `--workspace`.              |
+| `package_name`      | No       | —                             | Crate name to publish (e.g. `hopr-types`). When empty, defaults to `--workspace`.              |
 | `architecture`      | Yes      | —                             | Target architecture (e.g. `x86_64-linux`)                                                |
 | `cachix_cache_name` | No       | —                             | Cachix cache name                                                                        |
 | `nix_path`          | No       | `nixpkgs=channel:nixos-26.05` | Nix path to use                                                                          |

--- a/.github/workflows/build-library.md
+++ b/.github/workflows/build-library.md
@@ -21,11 +21,18 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 ```
 
-To verify (or publish) against explicit Rust target triples instead of the runner's host default, supply `targets`:
+To verify (or publish) against explicit Rust target triples instead of the runner's host default, supply `targets`. GitHub Actions `workflow_call` inputs have no list type, so use either a space-separated inline string or a YAML block scalar — both work:
 
 ```yaml
     with:
       targets: "x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
+```
+
+```yaml
+    with:
+      targets: |
+        x86_64-unknown-linux-gnu
+        aarch64-unknown-linux-gnu
 ```
 
 `package_name` also accepts `--workspace` directly to make the workspace selection explicit:
@@ -50,7 +57,7 @@ To verify (or publish) against explicit Rust target triples instead of the runne
 | `timeout_minutes`   | No       | `60`                          | Timeout in minutes                                                                       |
 | `runner`            | Yes      | —                             | Runner label for the job                                                                 |
 | `enabled`           | No       | `true`                        | Whether to run this job                                                                  |
-| `targets`           | No       | `""`                          | Space-separated Rust target triples passed as repeated `--target` flags to `cargo release publish`. Empty (default) verifies against the host triple only. |
+| `targets`           | No       | `""`                          | Rust target triples passed as repeated `--target` flags to `cargo release publish`. Accepts a space-separated string or a YAML block scalar (`|`). Empty (default) verifies against the host triple only. |
 
 ## Secrets
 

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -87,18 +87,14 @@ jobs:
         if: inputs.version_type != 'release'
         shell: bash
         env:
-          CONTEXT: ${{ inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
+          CONTEXT: ${{ startsWith(inputs.package_name, '--') && inputs.package_name || inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
           TARGETS: ${{ inputs.targets }}
         run: |
-          context_override=""
           target_args=""
           for t in $TARGETS; do
-            case "$t" in
-              --workspace) context_override="--workspace" ;;
-              *) target_args="$target_args --target $t" ;;
-            esac
+            target_args="$target_args --target $t"
           done
-          nix develop -c cargo release publish ${context_override:-$CONTEXT} $target_args --all-features
+          nix develop -c cargo release publish $CONTEXT $target_args --all-features
       - name: Authenticate with crates.io
         if: inputs.version_type == 'release'
         id: auth
@@ -108,15 +104,11 @@ jobs:
         shell: bash
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-          CONTEXT: ${{ inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
+          CONTEXT: ${{ startsWith(inputs.package_name, '--') && inputs.package_name || inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
           TARGETS: ${{ inputs.targets }}
         run: |
-          context_override=""
           target_args=""
           for t in $TARGETS; do
-            case "$t" in
-              --workspace) context_override="--workspace" ;;
-              *) target_args="$target_args --target $t" ;;
-            esac
+            target_args="$target_args --target $t"
           done
-          nix develop -c cargo release publish ${context_override:-$CONTEXT} $target_args --execute --all-features --no-confirm
+          nix develop -c cargo release publish $CONTEXT $target_args --execute --all-features --no-confirm

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -1,4 +1,3 @@
----
 #################################################################################
 # Pipeline to build libraries
 #################################################################################
@@ -51,14 +50,12 @@ on:
         required: false
         type: string
         default: ""
-        description: "Space-separated Rust target triples passed as repeated --target flags to cargo release publish. Empty
-          (default) verifies against the host triple only."
+        description: "Space-separated Rust target triples passed as repeated --target flags to cargo release publish. Empty (default) verifies against the host triple only."
     secrets:
       cachix_auth_token:
         required: true
 concurrency:
-  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-${{ inputs.architecture }}-${{ inputs.package_name
-    }}-library
+  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-${{ inputs.architecture }}-${{ inputs.package_name }}-library
   cancel-in-progress: true
 permissions:
   contents: read

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -1,3 +1,4 @@
+---
 #################################################################################
 # Pipeline to build libraries
 #################################################################################
@@ -50,12 +51,14 @@ on:
         required: false
         type: string
         default: ""
-        description: "Space-separated Rust target triples passed as repeated --target flags to cargo release publish. Empty (default) verifies against the host triple only."
+        description: "Space-separated Rust target triples passed as repeated --target flags to cargo release publish. Empty
+          (default) verifies against the host triple only."
     secrets:
       cachix_auth_token:
         required: true
 concurrency:
-  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-${{ inputs.architecture }}-${{ inputs.package_name }}-library
+  group: ${{ github.repository }}-${{ inputs.source_branch }}-${{ github.workflow }}-${{ inputs.architecture }}-${{ inputs.package_name
+    }}-library
   cancel-in-progress: true
 permissions:
   contents: read
@@ -107,7 +110,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
           CONTEXT: ${{ inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
           TARGETS: ${{ inputs.targets }}
-        run: |
+        run: |-
           target_args=""
           for t in $TARGETS; do
             [[ "$t" =~ ^[a-zA-Z0-9_-]+$ ]] || { echo "::error::Invalid target triple: $t"; exit 1; }

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -46,6 +46,11 @@ on:
         type: boolean
         default: true
         description: "Whether to run this job"
+      targets:
+        required: false
+        type: string
+        default: ""
+        description: "Space-separated Rust target triples passed as repeated --target flags to cargo release publish. Empty (default) verifies against the host triple only."
     secrets:
       cachix_auth_token:
         required: true
@@ -81,9 +86,15 @@ jobs:
       - name: Build dry-run library
         if: inputs.version_type != 'release'
         shell: bash
-        run: nix develop -c cargo release publish $CONTEXT --all-features
         env:
           CONTEXT: ${{ inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
+          TARGETS: ${{ inputs.targets }}
+        run: |
+          target_args=""
+          for t in $TARGETS; do
+            target_args="$target_args --target $t"
+          done
+          nix develop -c cargo release publish $CONTEXT $target_args --all-features
       - name: Authenticate with crates.io
         if: inputs.version_type == 'release'
         id: auth
@@ -94,4 +105,10 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
           CONTEXT: ${{ inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
-        run: nix develop -c cargo release publish $CONTEXT --execute --all-features --no-confirm
+          TARGETS: ${{ inputs.targets }}
+        run: |
+          target_args=""
+          for t in $TARGETS; do
+            target_args="$target_args --target $t"
+          done
+          nix develop -c cargo release publish $CONTEXT $target_args --execute --all-features --no-confirm

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -87,7 +87,7 @@ jobs:
         if: inputs.version_type != 'release'
         shell: bash
         env:
-          CONTEXT: ${{ startsWith(inputs.package_name, '--') && inputs.package_name || inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
+          CONTEXT: ${{ inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
           TARGETS: ${{ inputs.targets }}
         run: |
           target_args=""
@@ -105,7 +105,7 @@ jobs:
         shell: bash
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-          CONTEXT: ${{ startsWith(inputs.package_name, '--') && inputs.package_name || inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
+          CONTEXT: ${{ inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
           TARGETS: ${{ inputs.targets }}
         run: |
           target_args=""

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -92,7 +92,8 @@ jobs:
         run: |
           target_args=""
           for t in $TARGETS; do
-            target_args="$target_args --target $t"
+            [[ "$t" =~ ^[a-zA-Z0-9_-]+$ ]] || { echo "::error::Invalid target triple: $t"; exit 1; }
+            target_args="${target_args:+$target_args }--target $t"
           done
           nix develop -c cargo release publish $CONTEXT $target_args --all-features
       - name: Authenticate with crates.io
@@ -109,6 +110,7 @@ jobs:
         run: |
           target_args=""
           for t in $TARGETS; do
-            target_args="$target_args --target $t"
+            [[ "$t" =~ ^[a-zA-Z0-9_-]+$ ]] || { echo "::error::Invalid target triple: $t"; exit 1; }
+            target_args="${target_args:+$target_args }--target $t"
           done
           nix develop -c cargo release publish $CONTEXT $target_args --execute --all-features --no-confirm

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -90,11 +90,15 @@ jobs:
           CONTEXT: ${{ inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
           TARGETS: ${{ inputs.targets }}
         run: |
+          context_override=""
           target_args=""
           for t in $TARGETS; do
-            target_args="$target_args --target $t"
+            case "$t" in
+              --workspace) context_override="--workspace" ;;
+              *) target_args="$target_args --target $t" ;;
+            esac
           done
-          nix develop -c cargo release publish $CONTEXT $target_args --all-features
+          nix develop -c cargo release publish ${context_override:-$CONTEXT} $target_args --all-features
       - name: Authenticate with crates.io
         if: inputs.version_type == 'release'
         id: auth
@@ -107,8 +111,12 @@ jobs:
           CONTEXT: ${{ inputs.package_name != '' && format('--package {0}', inputs.package_name) || '--workspace' }}
           TARGETS: ${{ inputs.targets }}
         run: |
+          context_override=""
           target_args=""
           for t in $TARGETS; do
-            target_args="$target_args --target $t"
+            case "$t" in
+              --workspace) context_override="--workspace" ;;
+              *) target_args="$target_args --target $t" ;;
+            esac
           done
-          nix develop -c cargo release publish $CONTEXT $target_args --execute --all-features --no-confirm
+          nix develop -c cargo release publish ${context_override:-$CONTEXT} $target_args --execute --all-features --no-confirm


### PR DESCRIPTION
## Summary

- Adds an optional `targets` input to `build-library.yaml` for specifying Rust target triples passed as repeated `--target` flags to `cargo release publish`
- `package_name` is optional; when empty it defaults to `--workspace` (behaviour unchanged for existing callers)
- Each token in `targets` is validated against `^[a-zA-Z0-9_-]+$` to prevent shell injection, with a `::error::` annotation on failure
- Docs: updated `uses:` ref to `build-library-v3`, corrected `package_name` to `No` in the Required column, removed stale `cargo_registry_token` from the Secrets table

**`targets` accepts a space-separated string or a YAML block scalar:**

```yaml
# inline
targets: "x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"

# block scalar
targets: |
  x86_64-unknown-linux-gnu
  aarch64-unknown-linux-gnu
```

Closes #34