### PR TITLE
Migrate tokens

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Bump version and push tag

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -67,7 +67,7 @@ jobs:
           disable-sudo: true
           egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           ref: ${{ inputs.source_branch }}
@@ -94,7 +94,7 @@ jobs:
           disable-sudo: true
           egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           ref: ${{ inputs.source_branch }}

--- a/.github/workflows/build-binaries.md
+++ b/.github/workflows/build-binaries.md
@@ -16,7 +16,7 @@ The `sign` job also uploads the binary (and signature/checksum) to Google Artifa
 ```yaml
 jobs:
   build:
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v3
     with:
       source_branch: ${{ github.ref_name }}
       version_type: commit
@@ -26,7 +26,6 @@ jobs:
       binary: hoprd
       runner: depot-ubuntu-22.04-4
     secrets:
-      gcp_service_account: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       gpg_private_key: ${{ secrets.GPG_HOPRNET_PRIVATE_KEY }}
 ```

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -103,7 +103,7 @@ jobs:
           disable-sudo: true
           egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           ref: ${{ inputs.source_branch }}

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -44,7 +44,7 @@ on:
         required: false
         type: string
         description: GCP Workload Identity Provider
-        default: projects/277369779617/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+        default: projects/277369779617/locations/global/workloadIdentityPools/github-workflow-pool/providers/github-provider
       gcp_service_account:
         required: false
         type: string

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -41,12 +41,12 @@ on:
         type: string
         description: "Binary name to build"
       gcp_workload_identity_provider:
-        required: true
+        required: false
         type: string
         description: GCP Workload Identity Provider
         default: projects/277369779617/locations/global/workloadIdentityPools/github-pool/providers/github-provider
       gcp_service_account:
-        required: true
+        required: false
         type: string
         description: GCP Service Account JSON for Artifact Registry access
         default: github-workflows@hoprassociation.iam.gserviceaccount.com

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -48,7 +48,7 @@ on:
       gcp_service_account:
         required: false
         type: string
-        description: GCP Service Account JSON for Artifact Registry access
+        description: GCP Service Account email for Artifact Registry access
         default: github-workflows@hoprassociation.iam.gserviceaccount.com
       gcp_region:
         description: GCP region for Artifact Registry

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -40,6 +40,16 @@ on:
         required: true
         type: string
         description: "Binary name to build"
+      gcp_workload_identity_provider:
+        required: true
+        type: string
+        description: GCP Workload Identity Provider
+        default: projects/277369779617/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+      gcp_service_account:
+        required: true
+        type: string
+        description: GCP Service Account JSON for Artifact Registry access
+        default: github-workflows@hoprassociation.iam.gserviceaccount.com
       gcp_region:
         description: GCP region for Artifact Registry
         type: string
@@ -65,12 +75,6 @@ on:
         default: true
         description: "Whether to run this job"
     secrets:
-      gcp_service_account:
-        required: false
-      gcp_workload_identity_provider:
-        required: false
-      gcp_workload_identity_service_account:
-        required: false
       cachix_auth_token:
         required: true
       gpg_private_key:
@@ -195,11 +199,10 @@ jobs:
           path: ${{ github.workspace }}/artifacts/*-${{ inputs.architecture}}.sha256
       - name: Setup GCP
         if: needs.build.outputs.publish_artifact_registry == 'true'
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v4
         with:
-          google_credentials: ${{ secrets.gcp_service_account }}
-          workload_identity_provider: ${{ secrets.gcp_workload_identity_provider }}
-          service_account: ${{ secrets.gcp_workload_identity_service_account }}
+          workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+          service_account: ${{ inputs.gcp_service_account }}
           install_sdk: "true"
       - name: Publish ${{ inputs.binary }}-${{ inputs.architecture }} into Google Artifact registry
         if: needs.build.outputs.publish_artifact_registry == 'true'

--- a/.github/workflows/build-docker.md
+++ b/.github/workflows/build-docker.md
@@ -18,7 +18,7 @@ Builds platform-specific Docker images using Nix and creates a multi-architectur
 jobs:
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v3
     needs: build-binaries
     permissions:
       contents: read
@@ -40,7 +40,6 @@ jobs:
       docker_image_name: "hoprd"
       docker_image_format: skopeo
     secrets:
-      gcp_service_account: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -131,7 +131,7 @@ jobs:
           disable-sudo: true
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           ref: ${{ inputs.source_branch }}
@@ -496,7 +496,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           ref: ${{ inputs.source_branch }}

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -94,7 +94,7 @@ on:
         required: false
         type: string
         description: GCP Workload Identity Provider
-        default: projects/277369779617/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+        default: projects/277369779617/locations/global/workloadIdentityPools/github-workflow-pool/providers/github-provider
       gcp_service_account:
         required: false
         type: string

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -91,12 +91,12 @@ on:
         description: "Runner to use for the build job"
         default: depot-ubuntu-22.04-4
       gcp_workload_identity_provider:
-        required: true
+        required: false
         type: string
         description: GCP Workload Identity Provider
         default: projects/277369779617/locations/global/workloadIdentityPools/github-pool/providers/github-provider
       gcp_service_account:
-        required: true
+        required: false
         type: string
         description: GCP Service Account JSON for Artifact Registry access
         default: github-workflows@hoprassociation.iam.gserviceaccount.com

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -90,9 +90,17 @@ on:
         type: string
         description: "Runner to use for the build job"
         default: depot-ubuntu-22.04-4
-    secrets:
+      gcp_workload_identity_provider:
+        required: true
+        type: string
+        description: GCP Workload Identity Provider
+        default: projects/277369779617/locations/global/workloadIdentityPools/github-pool/providers/github-provider
       gcp_service_account:
         required: true
+        type: string
+        description: GCP Service Account JSON for Artifact Registry access
+        default: github-workflows@hoprassociation.iam.gserviceaccount.com
+    secrets:
       cachix_auth_token:
         required: true
       docker_hub_username:
@@ -173,9 +181,10 @@ jobs:
         run: ${{ matrix.build_debug_command }}
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v4
         with:
-          google_credentials: ${{ secrets.gcp_service_account }}
+          workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+          service_account: ${{ inputs.gcp_service_account }}
           login_artifact_registry: 'true'
       - name: Log in to DockerHub
         if: steps.docker_hub.outputs.publish_docker_hub == 'true'
@@ -266,9 +275,10 @@ jobs:
     steps:
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v4
         with:
-          google_credentials: ${{ secrets.gcp_service_account }}
+          workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+          service_account: ${{ inputs.gcp_service_account }}
           login_artifact_registry: 'true'
           install_sdk: 'false'
       - name: Create multi-arch docker manifest - ${{ needs.build.outputs.docker_build_version }}
@@ -366,9 +376,10 @@ jobs:
           cosign-release: 'v3.0.5'
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v4
         with:
-          google_credentials: ${{ secrets.gcp_service_account }}
+          workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+          service_account: ${{ inputs.gcp_service_account }}
           login_artifact_registry: 'true'
           install_sdk: 'true'
       - name: Compute platform-specific tags
@@ -541,9 +552,10 @@ jobs:
     steps:
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v4
         with:
-          google_credentials: ${{ secrets.gcp_service_account }}
+          workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+          service_account: ${{ inputs.gcp_service_account }}
           install_sdk: 'true'
           login_gke: 'true'
           gke_project: hopr-staging

--- a/.github/workflows/build-library.yaml
+++ b/.github/workflows/build-library.yaml
@@ -70,7 +70,7 @@ jobs:
           disable-sudo: true
           egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           ref: ${{ inputs.source_branch }}

--- a/.github/workflows/cleanup-registry.yaml
+++ b/.github/workflows/cleanup-registry.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           disable-sudo: false
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Setup GCP

--- a/.github/workflows/cleanup-registry.yaml
+++ b/.github/workflows/cleanup-registry.yaml
@@ -25,9 +25,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup GCP
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v4
         with:
-          google_credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER_GITHUB }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
           install_sdk: "true"
       - name: Setup Nix
         uses: hoprnet/hopr-workflows/actions/setup-nix@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2

--- a/actions/nix-action/action.yaml
+++ b/actions/nix-action/action.yaml
@@ -39,7 +39,7 @@ runs:
         disable-sudo: ${{ inputs.disable_sudo }}
         egress-policy: audit
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: ${{ inputs.persist_credentials }}
         ref: ${{ inputs.source_branch }}

--- a/actions/publish-rust-docs/action.yaml
+++ b/actions/publish-rust-docs/action.yaml
@@ -31,7 +31,7 @@ runs:
   using: composite
   steps:
     - name: Checkout repo
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
         repository: ${{ inputs.source_repo }}

--- a/actions/release-version/README.md
+++ b/actions/release-version/README.md
@@ -84,7 +84,7 @@ The release process follows a two-branch model: `main` for active development an
 
 ```bash
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@release-version-v4
+        uses: hoprnet/hopr-workflows/actions/release-version@release-version-v5
         with:
           source_branch: main
           file: Cargo.toml
@@ -97,7 +97,7 @@ The release process follows a two-branch model: `main` for active development an
           zulip_topic: "Releases"
           gcp_service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_GITHUB_ACTIONS }}
           gcp_artifact_package: my-package
-          github_token: "${{ secrets.GH_RUNNER_TOKEN }}"
+          github_app_private_key: "${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}"
           draft: 'true'
           override: 'false'
 ```
@@ -126,7 +126,7 @@ The release process follows a two-branch model: `main` for active development an
 - `gcp_artifact_repository`: GCP Artifact Registry repository name.
 - `gcp_artifact_package`: Package name from Google Artifact Registry to download binaries from and publish in the release.
 - `release_notes_file`: Path to a file containing release notes. If empty (default), release notes are auto-generated from the git history using the `generate-release-notes` action.
-- `github_token`: GitHub Token from the Bot with permission to make direct commits into the branch.
+- `github_app_private_key`: GitHub App Private Key from the Bot with permission to make direct commits and releases
 - `draft`: Whether to create a draft release
 - `override`: Whether to allow updating an existing release for the target tag. When `false` (default), the action fails if the release already exists.
 

--- a/actions/release-version/README.md
+++ b/actions/release-version/README.md
@@ -95,7 +95,6 @@ The release process follows a two-branch model: `main` for active development an
           zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
           zulip_channel: "MyChannel"
           zulip_topic: "Releases"
-          gcp_service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_GITHUB_ACTIONS }}
           gcp_artifact_package: my-package
           github_app_private_key: "${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}"
           draft: 'true'
@@ -121,7 +120,8 @@ The release process follows a two-branch model: `main` for active development an
 - `zulip_api_key`: Api key of the zulip user.
 - `zulip_channel`: Zulip channel for notifications.
 - `zulip_topic`: Zulip topic for notifications.
-- `gcp_service_account`: GCP Service Account JSON for Artifact Registry access.
+- `gcp_workload_identity_provider`: GCP Workload Identity Provider
+- `gcp_service_account`: The service account email linked to the workload identity provider on GCP
 - `gcp_artifact_region`: GCP region for Artifact Registry.
 - `gcp_artifact_repository`: GCP Artifact Registry repository name.
 - `gcp_artifact_package`: Package name from Google Artifact Registry to download binaries from and publish in the release.

--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -65,8 +65,8 @@ inputs:
     description: Path to a file containing release notes. If empty, release notes will be auto-generated.
     required: false
     default: ''
-  github_token:
-    description: GitHub Token from the Bot with permission to make direct commits into the branch
+  github_app_private_key:
+    description: GitHub App Private Key from the Bot with permission to make direct commits and releases
     required: true
 outputs:
   current_version:
@@ -78,13 +78,19 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Generate short-lived github token from GitHub App Hoprnet
+      id: bot-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        client-id: ${{ vars.GH_APP_HOPRNET_BOT_CLIENT_ID }}
+        private-key: ${{ inputs.github_app_private_key }}
     - name: Checkout hoprnet repository
-      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{ inputs.source_branch }}
         fetch-depth: 0
         fetch-tags: true
-        token: ${{ inputs.github_token }}
+        token: ${{ steps.bot-token.outputs.token }}
         clean: ${{ inputs.release_notes_file == '' }}
     - name: Get version info
       id: version
@@ -124,7 +130,7 @@ runs:
     - name: Check release existence
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
       run: |
         tag="${{ inputs.release_tag_prefix }}${{ steps.version.outputs.current_version }}"
         release_exists="false"
@@ -169,7 +175,7 @@ runs:
       with:
         file: ${{ inputs.file }}
         release_type: ${{ inputs.release_type }}
-        github_token: ${{ inputs.github_token }}
+        github_token: ${{ steps.bot-token.outputs.token }}
     - name: Prepare notification message
       shell: bash
       if: ${{ inputs.zulip_api_key && inputs.zulip_email && inputs.zulip_channel && inputs.zulip_topic }}

--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -52,7 +52,7 @@ inputs:
     required: false
     default: projects/277369779617/locations/global/workloadIdentityPools/github-workflow-pool/providers/github-provider
   gcp_service_account:
-    description: GCP Service Account JSON for Artifact Registry access
+    description: GCP Service Account email for Artifact Registry access
     required: false
     default: github-workflows@hoprassociation.iam.gserviceaccount.com
   gcp_artifact_region:
@@ -104,7 +104,7 @@ runs:
         file: "${{ inputs.file }}"
         version_type: release
     - name: Setup GCP
-      if: inputs.gcp_service_account != '' && inputs.gcp_workload_identity_provider != ''
+      if: inputs.gcp_artifact_package != ''
       id: gcp
       uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v4
       with:

--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -50,7 +50,7 @@ inputs:
   gcp_workload_identity_provider:
     description: GCP Workload Identity Provider
     required: false
-    default: projects/277369779617/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+    default: projects/277369779617/locations/global/workloadIdentityPools/github-workflow-pool/providers/github-provider
   gcp_service_account:
     description: GCP Service Account JSON for Artifact Registry access
     required: false

--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -47,9 +47,14 @@ inputs:
   zulip_topic:
     description: Zulip topic for notifications
     required: false
+  gcp_workload_identity_provider:
+    description: GCP Workload Identity Provider
+    required: false
+    default: projects/277369779617/locations/global/workloadIdentityPools/github-pool/providers/github-provider
   gcp_service_account:
     description: GCP Service Account JSON for Artifact Registry access
     required: false
+    default: github-workflows@hoprassociation.iam.gserviceaccount.com
   gcp_artifact_region:
     description: GCP region for Artifact Registry
     required: false
@@ -99,11 +104,12 @@ runs:
         file: "${{ inputs.file }}"
         version_type: release
     - name: Setup GCP
-      if: inputs.gcp_service_account != ''
+      if: inputs.gcp_service_account != '' && inputs.gcp_workload_identity_provider != ''
       id: gcp
-      uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3
+      uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v4
       with:
-        google_credentials: ${{ inputs.gcp_service_account }}
+        workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+        service_account: ${{ inputs.gcp_service_account }}
         login_artifact_registry: 'true'
         install_sdk: 'true'
     - name: Setup Nix

--- a/actions/setup-gcp/README.md
+++ b/actions/setup-gcp/README.md
@@ -7,9 +7,10 @@ This action compiles a set of tasks to install and authenticate against GCP
 ```bash
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v4
         with:
-          google_credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_GITHUB_ACTIONS }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER_GITHUB }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
           install_sdk: "true"
           login_artifact_registry: "true"
           login_gke: "true"
@@ -24,9 +25,8 @@ None
 
 ## Inputs
 
-- `google_credentials`: This is the Google service account in JSON format with permissions to interact from GitHub in GCP.
 - `workload_identity_provider`: The workload identity provider to authenticate on GCP.
-- `service_account`: The service account for the workload identity provider on GCP.
+- `service_account`: The service account email linked to the workload identity provider on GCP.
 - `install_sdk`: Determines if the GCloud cli command line needs to be installed.
 - `login_artifact_registry`: Determines if the service account needs to login in the Google Artifact registry to be able to publish new artifacts.
 - `login_gke`: Determines if the service account needs to be logged in into the Kubernetes cluster.

--- a/actions/setup-gcp/action.yaml
+++ b/actions/setup-gcp/action.yaml
@@ -1,15 +1,12 @@
 name: Setup GCP
 description: Install GCP tools and authenticate
 inputs:
-  google_credentials:
-    description: Google credentials taken from secret GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY
-    required: false
   workload_identity_provider:
     description: Workload Identity Provider
-    required: false
+    required: true
   service_account:
     description: Service Account email
-    required: false
+    required: true
   install_sdk:
     description: Install SDK
     required: false
@@ -41,16 +38,8 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Authenticate in Google Cloud using JSON Account Key
-      if: inputs.google_credentials != ''
-      id: auth_credentials
-      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-      with:
-        token_format: access_token
-        credentials_json: ${{ inputs.google_credentials }}
     - name: Authenticate in Google Cloud using Workload Identity
       id: auth_workload_identity
-      if: inputs.workload_identity_provider != '' && inputs.service_account != ''
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         token_format: access_token


### PR DESCRIPTION
- Instead of using a PAT Token from a specific user, it will be using a Github App to perform operations
- Change GCP integration to disable JSON token. Only Workload Identity provider is supported.
Tags updated:
- `setup-gcp-v4`
- `release-version-v5`
- `build-docker-v3`
- `build-binaries-v3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows and composite actions to use pinned, stable checkout action revisions for improved reliability and security.
  * Migrated CI/CD Google Cloud authentication to workload identity–based inputs (replacing prior service-account JSON credential handling) across build, deploy, and maintenance workflows.
  * Updated release automation to use GitHub App credentials instead of a static token.

* **Documentation**
  * Refreshed setup and release workflow documentation to reflect the new GitHub App and workload identity inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Breaking changes**
- The action `setup-gcp` has restricted authentication to use only Workload Identity Provider.
- The action `release-version` has restricted authentication to use only Workload Identity provider.
- The workflow `build-binary.yaml` has changed GCP authentication to use Workload Identity Provider
- The workflow `build-docker.yaml` has changed GCP authentication to use Workload Identity Provider