### PR TITLE
feat(ci): add actionlint + pinact pre-commit hooks for workflow validation

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - name: Bump version and push tag
         id: tag_action
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: ""

--- a/actions/setup-gcp/action.yaml
+++ b/actions/setup-gcp/action.yaml
@@ -42,7 +42,7 @@ runs:
   steps:
     - name: Authenticate in Google Cloud using Workload Identity
       id: auth_workload_identity
-      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         token_format: access_token
         workload_identity_provider: ${{ inputs.workload_identity_provider }}

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,19 @@
                 language = "system";
                 pass_filenames = true;
               };
+              actionlint = {
+                enable = true;
+              };
+              pinact = {
+                enable = true;
+                name = "pinact";
+                description = "Check GitHub Action refs are SHA-pinned and resolvable";
+                # Exclude self-referencing composite action paths that pinact cannot resolve
+                entry = "${pkgs.pinact}/bin/pinact run --check --exclude '^hoprnet/hopr-workflows'";
+                files = "\\.ya?ml$";
+                language = "system";
+                pass_filenames = false;
+              };
             };
             tools = pkgs;
           };
@@ -75,6 +88,7 @@
             ];
             shellHook = ''
               ${pre-commit-check.shellHook}
+              export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
             '';
           };
           apps.cleanup-docker-images = flake-utils.lib.mkApp {


### PR DESCRIPTION
Adds two pre-commit hooks via `cachix/git-hooks.nix` to validate GitHub Actions workflow files before every commit:

- **`actionlint`** — static YAML/expression syntax validation and shellcheck on `run:` blocks
- **`pinact run --check`** — enforces that every `uses:` ref is SHA-pinned and resolves against the GitHub API

Self-referencing composite action paths (`hoprnet/hopr-workflows/actions/*`) are excluded from pinact since they use component-version tags that pinact cannot resolve via the API.

Also:
- Pins `mathieudutour/github-tag-action@v6.2` to its full SHA
- Fixes the version comment on `google-github-actions/auth` from `# v3` to `# v3.0.0`
- Exports `GITHUB_TOKEN` in the devshell `shellHook` so pinact makes authenticated API calls locally