### PR TITLE
fix(release-version): replace vars context with input for GitHub App client ID

### DIFF
--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -70,6 +70,10 @@ inputs:
     description: Path to a file containing release notes. If empty, release notes will be auto-generated.
     required: false
     default: ''
+  github_app_client_id:
+    description: GitHub App Client ID of the Bot used to mint the short-lived token
+    required: false
+    default: Iv23liV1vEl5aA1L93To
   github_app_private_key:
     description: GitHub App Private Key from the Bot with permission to make direct commits and releases
     required: true
@@ -87,7 +91,7 @@ runs:
       id: bot-token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        client-id: ${{ vars.GH_APP_HOPRNET_BOT_CLIENT_ID }}
+        client-id: ${{ inputs.github_app_client_id }}
         private-key: ${{ inputs.github_app_private_key }}
     - name: Checkout hoprnet repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary

- The `vars` context is not available in composite action manifests — `vars.GH_APP_HOPRNET_BOT_CLIENT_ID` on line 90 of `action.yaml` caused GitHub to reject the action at load time with `Unrecognized named-value: 'vars'`
- Add a new optional input `github_app_client_id` with the current client ID as the default
- Replace the broken `${{ vars.GH_APP_HOPRNET_BOT_CLIENT_ID }}` reference with `${{ inputs.github_app_client_id }}`
- Non-breaking: all existing callers continue to work without `with:` changes; the default supplies the correct value