### PR TITLE
feat: propose-ens-contenthash workflow

### DIFF
--- a/actions/propose-ens-contenthash/.gitignore
+++ b/actions/propose-ens-contenthash/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/actions/propose-ens-contenthash/README.md
+++ b/actions/propose-ens-contenthash/README.md
@@ -17,7 +17,6 @@ the ENS name. The proposal is signed by a **Safe delegate** (`ENS_DELEGATE_PRIVA
     SAFE_ADDRESS: "0x..." # Safe that owns the ENS name
     ENS_DELEGATE_PRIVATE_KEY: ${{ secrets.ENS_DELEGATE_PRIVATE_KEY }}
     SAFE_API_KEY: ${{ secrets.SAFE_API_KEY }} # required for Safe's hosted service
-    RPC_URL: ${{ secrets.RPC_URL }} # optional
 ```
 
 ## Requirements
@@ -39,10 +38,10 @@ the ENS name. The proposal is signed by a **Safe delegate** (`ENS_DELEGATE_PRIVA
 - `ENS_DELEGATE_PRIVATE_KEY`: Private key of the Safe delegate that proposes the transaction. Required.
 - `SAFE_API_KEY`: Safe Transaction Service API key. Required for the hosted service; may be omitted
   only when `SAFE_TX_SERVICE_URL` points at a self-hosted service. Default: empty.
-- `RPC_URL`: Ethereum mainnet RPC URL. When empty, viem's built-in mainnet public RPC is used.
-  Default: empty.
 - `SAFE_TX_SERVICE_URL`: Custom Safe Transaction Service endpoint. When set, `SAFE_API_KEY` may be
   omitted. Default: empty (Safe's hosted mainnet service).
+- `TX_ORIGIN`: Free-text origin label attached to the proposed transaction (shown in the Safe UI).
+  Default: `hopr-workflows/propose-ens-contenthash`.
 
 ## Outputs
 

--- a/actions/propose-ens-contenthash/README.md
+++ b/actions/propose-ens-contenthash/README.md
@@ -8,22 +8,22 @@ the ENS name. The proposal is signed by a **Safe delegate** (`ENS_DELEGATE_PRIVA
 ## Usage
 
 ```yaml
-      - name: Update ENS contenthash
-        uses: hoprnet/hopr-workflows/actions/propose-ens-contenthash@propose-ens-contenthash-v1
-        with:
-          cid: ${{ needs.publish-ipfs.outputs.cid }}
-          ens_name: ${{ vars.ENS_NAME }}
-          resolver_address: "0x..."                              # ENS resolver holding the record
-          safe_address: "0x..."                                  # Safe that owns the ENS name
-          ens_delegate_private_key: ${{ secrets.ENS_DELEGATE_PRIVATE_KEY }}
-          safe_api_key: ${{ secrets.SAFE_API_KEY }}              # required for Safe's hosted service
-          rpc_url: ${{ secrets.RPC_URL }}                        # optional
+- name: Update ENS contenthash
+  uses: hoprnet/hopr-workflows/actions/propose-ens-contenthash@propose-ens-contenthash-v1
+  with:
+    CID: ${{ needs.publish-ipfs.outputs.cid }}
+    ENS_NAME: ${{ vars.ENS_NAME }}
+    RESOLVER_ADDRESS: "0x..." # ENS resolver holding the record
+    SAFE_ADDRESS: "0x..." # Safe that owns the ENS name
+    ENS_DELEGATE_PRIVATE_KEY: ${{ secrets.ENS_DELEGATE_PRIVATE_KEY }}
+    SAFE_API_KEY: ${{ secrets.SAFE_API_KEY }} # required for Safe's hosted service
+    RPC_URL: ${{ secrets.RPC_URL }} # optional
 ```
 
 ## Requirements
 
-- The `ens_delegate_private_key` address must already be registered as a **delegate** on the
-  `safe_address` Safe (done once by a Safe owner — see
+- The `ENS_DELEGATE_PRIVATE_KEY` address must already be registered as a **delegate** on the
+  `SAFE_ADDRESS` Safe (done once by a Safe owner — see
   [Safe delegates](https://docs.safe.global/core-api/transaction-service-guides/delegates)).
 - The Safe must be the owner (or an approved operator) of the ENS name on the resolver.
 - A **Safe Transaction Service API key** is required when using Safe's hosted service. Obtain one
@@ -32,16 +32,16 @@ the ENS name. The proposal is signed by a **Safe delegate** (`ENS_DELEGATE_PRIVA
 
 ## Inputs
 
-- `cid`: IPFS CID (CIDv0 or CIDv1) to set as the ENS contenthash. Required.
-- `ens_name`: ENS name whose contenthash record is updated. Required.
-- `resolver_address`: Address of the ENS resolver contract that holds the record. Required.
-- `safe_address`: Address of the Safe multisig that owns the ENS name. Required.
-- `ens_delegate_private_key`: Private key of the Safe delegate that proposes the transaction. Required.
-- `safe_api_key`: Safe Transaction Service API key. Required for the hosted service; may be omitted
-  only when `safe_tx_service_url` points at a self-hosted service. Default: empty.
-- `rpc_url`: Ethereum mainnet RPC URL. When empty, viem's built-in mainnet public RPC is used.
+- `CID`: IPFS CID (CIDv0 or CIDv1) to set as the ENS contenthash. Required.
+- `ENS_NAME`: ENS name whose contenthash record is updated. Required.
+- `RESOLVER_ADDRESS`: Address of the ENS resolver contract that holds the record. Required.
+- `SAFE_ADDRESS`: Address of the Safe multisig that owns the ENS name. Required.
+- `ENS_DELEGATE_PRIVATE_KEY`: Private key of the Safe delegate that proposes the transaction. Required.
+- `SAFE_API_KEY`: Safe Transaction Service API key. Required for the hosted service; may be omitted
+  only when `SAFE_TX_SERVICE_URL` points at a self-hosted service. Default: empty.
+- `RPC_URL`: Ethereum mainnet RPC URL. When empty, viem's built-in mainnet public RPC is used.
   Default: empty.
-- `safe_tx_service_url`: Custom Safe Transaction Service endpoint. When set, `safe_api_key` may be
+- `SAFE_TX_SERVICE_URL`: Custom Safe Transaction Service endpoint. When set, `SAFE_API_KEY` may be
   omitted. Default: empty (Safe's hosted mainnet service).
 
 ## Outputs

--- a/actions/propose-ens-contenthash/README.md
+++ b/actions/propose-ens-contenthash/README.md
@@ -3,7 +3,7 @@
 This action takes an IPFS CID (e.g. produced by a previous workflow that publishes to IPFS),
 encodes it as an [EIP-1577](https://eips.ethereum.org/EIPS/eip-1577) `ipfs` contenthash, and
 **proposes** a `setContenthash` transaction to the [Safe](https://safe.global) multisig that owns
-the ENS name. The proposal is signed by a **Safe delegate** (`ENS_DELEGATE_PRIVATE_KEY`).
+the ENS name. The proposal is signed by a **Safe delegate** (`ens_delegate_private_key`).
 
 ## Usage
 
@@ -11,18 +11,18 @@ the ENS name. The proposal is signed by a **Safe delegate** (`ENS_DELEGATE_PRIVA
 - name: Update ENS contenthash
   uses: hoprnet/hopr-workflows/actions/propose-ens-contenthash@propose-ens-contenthash-v1
   with:
-    CID: ${{ needs.publish-ipfs.outputs.cid }}
-    ENS_NAME: ${{ vars.ENS_NAME }}
-    RESOLVER_ADDRESS: "0x..." # ENS resolver holding the record
-    SAFE_ADDRESS: "0x..." # Safe that owns the ENS name
-    ENS_DELEGATE_PRIVATE_KEY: ${{ secrets.ENS_DELEGATE_PRIVATE_KEY }}
-    SAFE_API_KEY: ${{ secrets.SAFE_API_KEY }} # required for Safe's hosted service
+    cid: ${{ needs.publish-ipfs.outputs.cid }}
+    ens_name: ${{ vars.ENS_NAME }}
+    resolver_address: "0x..." # ENS resolver holding the record
+    safe_address: "0x..." # Safe that owns the ENS name
+    ens_delegate_private_key: ${{ secrets.ENS_DELEGATE_PRIVATE_KEY }}
+    safe_api_key: ${{ secrets.SAFE_API_KEY }} # required for Safe's hosted service
 ```
 
 ## Requirements
 
-- The `ENS_DELEGATE_PRIVATE_KEY` address must already be registered as a **delegate** on the
-  `SAFE_ADDRESS` Safe (done once by a Safe owner — see
+- The `ens_delegate_private_key` address must already be registered as a **delegate** on the
+  `safe_address` Safe (done once by a Safe owner — see
   [Safe delegates](https://docs.safe.global/core-api/transaction-service-guides/delegates)).
 - The Safe must be the owner (or an approved operator) of the ENS name on the resolver.
 - A **Safe Transaction Service API key** is required when using Safe's hosted service. Obtain one
@@ -31,16 +31,16 @@ the ENS name. The proposal is signed by a **Safe delegate** (`ENS_DELEGATE_PRIVA
 
 ## Inputs
 
-- `CID`: IPFS CID (CIDv0 or CIDv1) to set as the ENS contenthash. Required.
-- `ENS_NAME`: ENS name whose contenthash record is updated. Required.
-- `RESOLVER_ADDRESS`: Address of the ENS resolver contract that holds the record. Required.
-- `SAFE_ADDRESS`: Address of the Safe multisig that owns the ENS name. Required.
-- `ENS_DELEGATE_PRIVATE_KEY`: Private key of the Safe delegate that proposes the transaction. Required.
-- `SAFE_API_KEY`: Safe Transaction Service API key. Required for the hosted service; may be omitted
-  only when `SAFE_TX_SERVICE_URL` points at a self-hosted service. Default: empty.
-- `SAFE_TX_SERVICE_URL`: Custom Safe Transaction Service endpoint. When set, `SAFE_API_KEY` may be
+- `cid`: IPFS CID (CIDv0 or CIDv1) to set as the ENS contenthash. Required.
+- `ens_name`: ENS name whose contenthash record is updated. Required.
+- `resolver_address`: Address of the ENS resolver contract that holds the record. Required.
+- `safe_address`: Address of the Safe multisig that owns the ENS name. Required.
+- `ens_delegate_private_key`: Private key of the Safe delegate that proposes the transaction. Required.
+- `safe_api_key`: Safe Transaction Service API key. Required for the hosted service; may be omitted
+  only when `safe_tx_service_url` points at a self-hosted service. Default: empty.
+- `safe_tx_service_url`: Custom Safe Transaction Service endpoint. When set, `safe_api_key` may be
   omitted. Default: empty (Safe's hosted mainnet service).
-- `TX_ORIGIN`: Free-text origin label attached to the proposed transaction (shown in the Safe UI).
+- `tx_origin`: Free-text origin label attached to the proposed transaction (shown in the Safe UI).
   Default: `hopr-workflows/propose-ens-contenthash`.
 
 ## Outputs

--- a/actions/propose-ens-contenthash/README.md
+++ b/actions/propose-ens-contenthash/README.md
@@ -1,0 +1,51 @@
+# Propose ENS Contenthash
+
+This action takes an IPFS CID (e.g. produced by a previous workflow that publishes to IPFS),
+encodes it as an [EIP-1577](https://eips.ethereum.org/EIPS/eip-1577) `ipfs` contenthash, and
+**proposes** a `setContenthash` transaction to the [Safe](https://safe.global) multisig that owns
+the ENS name. The proposal is signed by a **Safe delegate** (`ENS_DELEGATE_PRIVATE_KEY`).
+
+## Usage
+
+```yaml
+      - name: Update ENS contenthash
+        uses: hoprnet/hopr-workflows/actions/propose-ens-contenthash@propose-ens-contenthash-v1
+        with:
+          cid: ${{ needs.publish-ipfs.outputs.cid }}
+          ens_name: ${{ vars.ENS_NAME }}
+          resolver_address: "0x..."                              # ENS resolver holding the record
+          safe_address: "0x..."                                  # Safe that owns the ENS name
+          ens_delegate_private_key: ${{ secrets.ENS_DELEGATE_PRIVATE_KEY }}
+          safe_api_key: ${{ secrets.SAFE_API_KEY }}              # required for Safe's hosted service
+          rpc_url: ${{ secrets.RPC_URL }}                        # optional
+```
+
+## Requirements
+
+- The `ens_delegate_private_key` address must already be registered as a **delegate** on the
+  `safe_address` Safe (done once by a Safe owner — see
+  [Safe delegates](https://docs.safe.global/core-api/transaction-service-guides/delegates)).
+- The Safe must be the owner (or an approved operator) of the ENS name on the resolver.
+- A **Safe Transaction Service API key** is required when using Safe's hosted service. Obtain one
+  at <https://docs.safe.global/core-api/how-to-use-api-keys> and store it as `secrets.SAFE_API_KEY`.
+  This is only optional if you point `safe_tx_service_url` at a self-hosted Transaction Service.
+
+## Inputs
+
+- `cid`: IPFS CID (CIDv0 or CIDv1) to set as the ENS contenthash. Required.
+- `ens_name`: ENS name whose contenthash record is updated. Required.
+- `resolver_address`: Address of the ENS resolver contract that holds the record. Required.
+- `safe_address`: Address of the Safe multisig that owns the ENS name. Required.
+- `ens_delegate_private_key`: Private key of the Safe delegate that proposes the transaction. Required.
+- `safe_api_key`: Safe Transaction Service API key. Required for the hosted service; may be omitted
+  only when `safe_tx_service_url` points at a self-hosted service. Default: empty.
+- `rpc_url`: Ethereum mainnet RPC URL. When empty, viem's built-in mainnet public RPC is used.
+  Default: empty.
+- `safe_tx_service_url`: Custom Safe Transaction Service endpoint. When set, `safe_api_key` may be
+  omitted. Default: empty (Safe's hosted mainnet service).
+
+## Outputs
+
+- `safe_tx_hash`: Hash of the proposed Safe transaction.
+- `content_hash`: The encoded ENS contenthash (`0x…`) that was proposed.
+- `namehash`: The ENS node hash of the name.

--- a/actions/propose-ens-contenthash/README.md
+++ b/actions/propose-ens-contenthash/README.md
@@ -48,3 +48,6 @@ the ENS name. The proposal is signed by a **Safe delegate** (`ENS_DELEGATE_PRIVA
 - `safe_tx_hash`: Hash of the proposed Safe transaction.
 - `content_hash`: The encoded ENS contenthash (`0x…`) that was proposed.
 - `namehash`: The ENS node hash of the name.
+- `domain_hash`: EIP-712 domain hash of the Safe transaction (as shown in the Safe UI).
+- `message_hash`: EIP-712 message hash of the Safe transaction (as shown in the Safe UI).
+- `data`: The `setContenthash` calldata sent to the resolver.

--- a/actions/propose-ens-contenthash/action.yaml
+++ b/actions/propose-ens-contenthash/action.yaml
@@ -1,30 +1,30 @@
 name: Propose ENS Contenthash
 description: Encode an IPFS CID and propose a setContenthash transaction to the Safe that owns the ENS name, signed by a Safe delegate
 inputs:
-  CID:
+  cid:
     description: IPFS CID (CIDv0 or CIDv1) to set as the ENS contenthash
     required: true
-  ENS_NAME:
+  ens_name:
     description: ENS name whose contenthash record is updated (e.g. app.hoprnet.org)
     required: true
-  RESOLVER_ADDRESS:
+  resolver_address:
     description: Address of the ENS resolver contract that holds the record
     required: true
-  SAFE_ADDRESS:
+  safe_address:
     description: Address of the Safe multisig that owns the ENS name
     required: true
-  ENS_DELEGATE_PRIVATE_KEY:
+  ens_delegate_private_key:
     description: Private key of the Safe delegate that proposes the transaction
     required: true
-  SAFE_API_KEY:
-    description: Safe Transaction Service API key. Required when using Safe's hosted service (omit only when SAFE_TX_SERVICE_URL points at a self-hosted service)
+  safe_api_key:
+    description: Safe Transaction Service API key. Required when using Safe's hosted service (omit only when safe_tx_service_url points at a self-hosted service)
     required: false
     default: ""
-  SAFE_TX_SERVICE_URL:
-    description: Custom Safe Transaction Service endpoint. When set, SAFE_API_KEY may be omitted
+  safe_tx_service_url:
+    description: Custom Safe Transaction Service endpoint. When set, safe_api_key may be omitted
     required: false
     default: ""
-  TX_ORIGIN:
+  tx_origin:
     description: Free-text origin label attached to the proposed Safe transaction (shown in the Safe UI)
     required: false
     default: hopr-workflows/propose-ens-contenthash
@@ -53,21 +53,21 @@ runs:
     - name: Validate required inputs
       shell: bash
       env:
-        CID: ${{ inputs.CID }}
-        ENS_NAME: ${{ inputs.ENS_NAME }}
-        RESOLVER_ADDRESS: ${{ inputs.RESOLVER_ADDRESS }}
-        SAFE_ADDRESS: ${{ inputs.SAFE_ADDRESS }}
-        ENS_DELEGATE_PRIVATE_KEY: ${{ inputs.ENS_DELEGATE_PRIVATE_KEY }}
-        SAFE_API_KEY: ${{ inputs.SAFE_API_KEY }}
-        SAFE_TX_SERVICE_URL: ${{ inputs.SAFE_TX_SERVICE_URL }}
+        cid: ${{ inputs.cid }}
+        ens_name: ${{ inputs.ens_name }}
+        resolver_address: ${{ inputs.resolver_address }}
+        safe_address: ${{ inputs.safe_address }}
+        ens_delegate_private_key: ${{ inputs.ens_delegate_private_key }}
+        safe_api_key: ${{ inputs.safe_api_key }}
+        safe_tx_service_url: ${{ inputs.safe_tx_service_url }}
       run: |
         set -euo pipefail
         MISSING=0
-        for n in CID ENS_NAME RESOLVER_ADDRESS SAFE_ADDRESS ENS_DELEGATE_PRIVATE_KEY; do
+        for n in cid ens_name resolver_address safe_address ens_delegate_private_key; do
           [ -n "${!n:-}" ] || { echo "::error::$n is required but not set"; MISSING=1; }
         done
-        if [ -z "${SAFE_API_KEY:-}" ] && [ -z "${SAFE_TX_SERVICE_URL:-}" ]; then
-          echo "::error::SAFE_API_KEY is required when using the hosted Safe Transaction Service (or set SAFE_TX_SERVICE_URL to a self-hosted service)"
+        if [ -z "${safe_api_key:-}" ] && [ -z "${safe_tx_service_url:-}" ]; then
+          echo "::error::safe_api_key is required when using the hosted Safe Transaction Service (or set safe_tx_service_url to a self-hosted service)"
           MISSING=1
         fi
         if [ "$MISSING" -ne 0 ]; then exit 1; fi
@@ -89,40 +89,40 @@ runs:
       working-directory: ${{ github.action_path }}
       run: node ./propose-update.mjs
       env:
-        CID: ${{ inputs.CID }}
-        ENS_NAME: ${{ inputs.ENS_NAME }}
-        RESOLVER_ADDRESS: ${{ inputs.RESOLVER_ADDRESS }}
-        SAFE_ADDRESS: ${{ inputs.SAFE_ADDRESS }}
-        ENS_DELEGATE_PRIVATE_KEY: ${{ inputs.ENS_DELEGATE_PRIVATE_KEY }}
-        SAFE_API_KEY: ${{ inputs.SAFE_API_KEY }}
-        SAFE_TX_SERVICE_URL: ${{ inputs.SAFE_TX_SERVICE_URL }}
-        TX_ORIGIN: ${{ inputs.TX_ORIGIN }}
+        cid: ${{ inputs.cid }}
+        ens_name: ${{ inputs.ens_name }}
+        resolver_address: ${{ inputs.resolver_address }}
+        safe_address: ${{ inputs.safe_address }}
+        ens_delegate_private_key: ${{ inputs.ens_delegate_private_key }}
+        safe_api_key: ${{ inputs.safe_api_key }}
+        safe_tx_service_url: ${{ inputs.safe_tx_service_url }}
+        tx_origin: ${{ inputs.tx_origin }}
     - name: Write a summary of the proposed transaction
       shell: bash
       env:
-        ENS_NAME: ${{ inputs.ENS_NAME }}
-        SAFE_ADDRESS: ${{ inputs.SAFE_ADDRESS }}
-        CONTENT_HASH: ${{ steps.propose.outputs.content_hash }}
-        SAFE_TX_HASH: ${{ steps.propose.outputs.safe_tx_hash }}
-        NAMEHASH: ${{ steps.propose.outputs.namehash }}
-        DOMAIN_HASH: ${{ steps.propose.outputs.domain_hash }}
-        MESSAGE_HASH: ${{ steps.propose.outputs.message_hash }}
-        DATA: ${{ steps.propose.outputs.data }}
+        ens_name: ${{ inputs.ens_name }}
+        safe_address: ${{ inputs.safe_address }}
+        content_hash: ${{ steps.propose.outputs.content_hash }}
+        safe_tx_hash: ${{ steps.propose.outputs.safe_tx_hash }}
+        namehash: ${{ steps.propose.outputs.namehash }}
+        domain_hash: ${{ steps.propose.outputs.domain_hash }}
+        message_hash: ${{ steps.propose.outputs.message_hash }}
+        data: ${{ steps.propose.outputs.data }}
       run: |-
         {
           echo "## Proposed ENS contenthash update"
           echo ""
-          echo "A \`setContenthash\` transaction has been proposed for **${ENS_NAME}** and is awaiting Safe owner confirmation."
+          echo "A \`setContenthash\` transaction has been proposed for **${ens_name}** and is awaiting Safe owner confirmation."
           echo ""
           echo "| Field | Value |"
           echo "| --- | --- |"
-          echo "| ENS name | \`${ENS_NAME}\` |"
-          echo "| Node / Namehash | \`${NAMEHASH}\` |"
-          echo "| Content hash | \`${CONTENT_HASH}\` |"
-          echo "| Domain hash | \`${DOMAIN_HASH}\` |"
-          echo "| Message hash | \`${MESSAGE_HASH}\` |"
-          echo "| Safe TX hash | \`${SAFE_TX_HASH}\` |"
-          echo "| Data | \`${DATA}\` |"
+          echo "| ENS name | \`${ens_name}\` |"
+          echo "| Node / Namehash | \`${namehash}\` |"
+          echo "| Content hash | \`${content_hash}\` |"
+          echo "| Domain hash | \`${domain_hash}\` |"
+          echo "| Message hash | \`${message_hash}\` |"
+          echo "| Safe TX hash | \`${safe_tx_hash}\` |"
+          echo "| Data | \`${data}\` |"
           echo ""
-          echo "### 🔗 [Review and sign the TX in the Safe queue](https://app.safe.global/transactions/queue?safe=eth:${SAFE_ADDRESS})"
+          echo "### 🔗 [Review and sign the TX in the Safe queue](https://app.safe.global/transactions/queue?safe=eth:${safe_address})"
         } >> "$GITHUB_STEP_SUMMARY"

--- a/actions/propose-ens-contenthash/action.yaml
+++ b/actions/propose-ens-contenthash/action.yaml
@@ -1,31 +1,31 @@
 name: Propose ENS Contenthash
 description: Encode an IPFS CID and propose a setContenthash transaction to the Safe that owns the ENS name, signed by a Safe delegate
 inputs:
-  cid:
+  CID:
     description: IPFS CID (CIDv0 or CIDv1) to set as the ENS contenthash
     required: true
-  ens_name:
+  ENS_NAME:
     description: ENS name whose contenthash record is updated (e.g. ${{ vars.ENS_NAME }})
     required: true
-  resolver_address:
+  RESOLVER_ADDRESS:
     description: Address of the ENS resolver contract that holds the record
     required: true
-  safe_address:
+  SAFE_ADDRESS:
     description: Address of the Safe multisig that owns the ENS name
     required: true
-  ens_delegate_private_key:
+  ENS_DELEGATE_PRIVATE_KEY:
     description: Private key of the Safe delegate that proposes the transaction
     required: true
-  rpc_url:
+  RPC_URL:
     description: Ethereum mainnet RPC URL. When empty, viem's built-in mainnet public RPC is used
     required: false
     default: ""
-  safe_api_key:
-    description: Safe Transaction Service API key. Required when using Safe's hosted service (omit only when safe_tx_service_url points at a self-hosted service)
+  SAFE_API_KEY:
+    description: Safe Transaction Service API key. Required when using Safe's hosted service (omit only when SAFE_TX_SERVICE_URL points at a self-hosted service)
     required: false
     default: ""
-  safe_tx_service_url:
-    description: Custom Safe Transaction Service endpoint. When set, safe_api_key may be omitted
+  SAFE_TX_SERVICE_URL:
+    description: Custom Safe Transaction Service endpoint. When set, SAFE_API_KEY may be omitted
     required: false
     default: ""
 outputs:
@@ -61,11 +61,11 @@ runs:
       working-directory: ${{ github.action_path }}
       run: node ./propose-update.mjs
       env:
-        CID: ${{ inputs.cid }}
-        ENS_NAME: ${{ inputs.ens_name }}
-        RESOLVER_ADDRESS: ${{ inputs.resolver_address }}
-        SAFE_ADDRESS: ${{ inputs.safe_address }}
-        ENS_DELEGATE_PRIVATE_KEY: ${{ inputs.ens_delegate_private_key }}
-        RPC_URL: ${{ inputs.rpc_url }}
-        SAFE_API_KEY: ${{ inputs.safe_api_key }}
-        SAFE_TX_SERVICE_URL: ${{ inputs.safe_tx_service_url }}
+        CID: ${{ inputs.CID }}
+        ENS_NAME: ${{ inputs.ENS_NAME }}
+        RESOLVER_ADDRESS: ${{ inputs.RESOLVER_ADDRESS }}
+        SAFE_ADDRESS: ${{ inputs.SAFE_ADDRESS }}
+        ENS_DELEGATE_PRIVATE_KEY: ${{ inputs.ENS_DELEGATE_PRIVATE_KEY }}
+        RPC_URL: ${{ inputs.RPC_URL }}
+        SAFE_API_KEY: ${{ inputs.SAFE_API_KEY }}
+        SAFE_TX_SERVICE_URL: ${{ inputs.SAFE_TX_SERVICE_URL }}

--- a/actions/propose-ens-contenthash/action.yaml
+++ b/actions/propose-ens-contenthash/action.yaml
@@ -5,7 +5,7 @@ inputs:
     description: IPFS CID (CIDv0 or CIDv1) to set as the ENS contenthash
     required: true
   ENS_NAME:
-    description: ENS name whose contenthash record is updated (e.g. ${{ vars.ENS_NAME }})
+    description: ENS name whose contenthash record is updated (e.g. app.hoprnet.org)
     required: true
   RESOLVER_ADDRESS:
     description: Address of the ENS resolver contract that holds the record
@@ -41,16 +41,35 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate required inputs
+      shell: bash
+      env:
+        CID: ${{ inputs.CID }}
+        ENS_NAME: ${{ inputs.ENS_NAME }}
+        RESOLVER_ADDRESS: ${{ inputs.RESOLVER_ADDRESS }}
+        SAFE_ADDRESS: ${{ inputs.SAFE_ADDRESS }}
+        ENS_DELEGATE_PRIVATE_KEY: ${{ inputs.ENS_DELEGATE_PRIVATE_KEY }}
+        SAFE_API_KEY: ${{ inputs.SAFE_API_KEY }}
+        SAFE_TX_SERVICE_URL: ${{ inputs.SAFE_TX_SERVICE_URL }}
+      run: |
+        set -euo pipefail
+        MISSING=0
+        for n in CID ENS_NAME RESOLVER_ADDRESS SAFE_ADDRESS ENS_DELEGATE_PRIVATE_KEY; do
+          [ -n "${!n:-}" ] || { echo "::error::$n is required but not set"; MISSING=1; }
+        done
+        if [ -z "${SAFE_API_KEY:-}" ] && [ -z "${SAFE_TX_SERVICE_URL:-}" ]; then
+          echo "::error::SAFE_API_KEY is required when using the hosted Safe Transaction Service (or set SAFE_TX_SERVICE_URL to a self-hosted service)"
+          MISSING=1
+        fi
+        if [ "$MISSING" -ne 0 ]; then exit 1; fi
     - name: Install pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       with:
-        package_json_file: ${{ github.action_path }}/package.json
+        version: 11
     - name: Setup Node.js
       uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
       with:
         node-version: 24
-        cache: pnpm
-        cache-dependency-path: ${{ github.action_path }}/pnpm-lock.yaml
     - name: Install dependencies
       shell: bash
       working-directory: ${{ github.action_path }}
@@ -69,3 +88,26 @@ runs:
         RPC_URL: ${{ inputs.RPC_URL }}
         SAFE_API_KEY: ${{ inputs.SAFE_API_KEY }}
         SAFE_TX_SERVICE_URL: ${{ inputs.SAFE_TX_SERVICE_URL }}
+    - name: Write a summary of the proposed transaction
+      shell: bash
+      env:
+        ENS_NAME: ${{ inputs.ENS_NAME }}
+        SAFE_ADDRESS: ${{ inputs.SAFE_ADDRESS }}
+        CONTENT_HASH: ${{ steps.propose.outputs.content_hash }}
+        SAFE_TX_HASH: ${{ steps.propose.outputs.safe_tx_hash }}
+        NAMEHASH: ${{ steps.propose.outputs.namehash }}
+      run: |-
+        {
+          echo "## Proposed ENS contenthash update"
+          echo ""
+          echo "A \`setContenthash\` transaction has been proposed for **${ENS_NAME}** and is awaiting Safe owner confirmation."
+          echo ""
+          echo "| Field | Value |"
+          echo "| --- | --- |"
+          echo "| ENS name | \`${ENS_NAME}\` |"
+          echo "| Contenthash | \`${CONTENT_HASH}\` |"
+          echo "| Safe tx hash | \`${SAFE_TX_HASH}\` |"
+          echo "| Namehash | \`${NAMEHASH}\` |"
+          echo ""
+          echo "[Review in the Safe queue](https://app.safe.global/transactions/queue?safe=eth:${SAFE_ADDRESS})"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/actions/propose-ens-contenthash/action.yaml
+++ b/actions/propose-ens-contenthash/action.yaml
@@ -16,10 +16,6 @@ inputs:
   ENS_DELEGATE_PRIVATE_KEY:
     description: Private key of the Safe delegate that proposes the transaction
     required: true
-  RPC_URL:
-    description: Ethereum mainnet RPC URL. When empty, viem's built-in mainnet public RPC is used
-    required: false
-    default: ""
   SAFE_API_KEY:
     description: Safe Transaction Service API key. Required when using Safe's hosted service (omit only when SAFE_TX_SERVICE_URL points at a self-hosted service)
     required: false
@@ -28,6 +24,10 @@ inputs:
     description: Custom Safe Transaction Service endpoint. When set, SAFE_API_KEY may be omitted
     required: false
     default: ""
+  TX_ORIGIN:
+    description: Free-text origin label attached to the proposed Safe transaction (shown in the Safe UI)
+    required: false
+    default: hopr-workflows/propose-ens-contenthash
 outputs:
   safe_tx_hash:
     description: Hash of the proposed Safe transaction
@@ -85,9 +85,9 @@ runs:
         RESOLVER_ADDRESS: ${{ inputs.RESOLVER_ADDRESS }}
         SAFE_ADDRESS: ${{ inputs.SAFE_ADDRESS }}
         ENS_DELEGATE_PRIVATE_KEY: ${{ inputs.ENS_DELEGATE_PRIVATE_KEY }}
-        RPC_URL: ${{ inputs.RPC_URL }}
         SAFE_API_KEY: ${{ inputs.SAFE_API_KEY }}
         SAFE_TX_SERVICE_URL: ${{ inputs.SAFE_TX_SERVICE_URL }}
+        TX_ORIGIN: ${{ inputs.TX_ORIGIN }}
     - name: Write a summary of the proposed transaction
       shell: bash
       env:

--- a/actions/propose-ens-contenthash/action.yaml
+++ b/actions/propose-ens-contenthash/action.yaml
@@ -1,0 +1,71 @@
+name: Propose ENS Contenthash
+description: Encode an IPFS CID and propose a setContenthash transaction to the Safe that owns the ENS name, signed by a Safe delegate
+inputs:
+  cid:
+    description: IPFS CID (CIDv0 or CIDv1) to set as the ENS contenthash
+    required: true
+  ens_name:
+    description: ENS name whose contenthash record is updated (e.g. ${{ vars.ENS_NAME }})
+    required: true
+  resolver_address:
+    description: Address of the ENS resolver contract that holds the record
+    required: true
+  safe_address:
+    description: Address of the Safe multisig that owns the ENS name
+    required: true
+  ens_delegate_private_key:
+    description: Private key of the Safe delegate that proposes the transaction
+    required: true
+  rpc_url:
+    description: Ethereum mainnet RPC URL. When empty, viem's built-in mainnet public RPC is used
+    required: false
+    default: ""
+  safe_api_key:
+    description: Safe Transaction Service API key. Required when using Safe's hosted service (omit only when safe_tx_service_url points at a self-hosted service)
+    required: false
+    default: ""
+  safe_tx_service_url:
+    description: Custom Safe Transaction Service endpoint. When set, safe_api_key may be omitted
+    required: false
+    default: ""
+outputs:
+  safe_tx_hash:
+    description: Hash of the proposed Safe transaction
+    value: ${{ steps.propose.outputs.safe_tx_hash }}
+  content_hash:
+    description: The encoded ENS contenthash (0x...) that was proposed
+    value: ${{ steps.propose.outputs.content_hash }}
+  namehash:
+    description: The ENS node hash of the name
+    value: ${{ steps.propose.outputs.namehash }}
+runs:
+  using: composite
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      with:
+        package_json_file: ${{ github.action_path }}/package.json
+    - name: Setup Node.js
+      uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+      with:
+        node-version: 24
+        cache: pnpm
+        cache-dependency-path: ${{ github.action_path }}/pnpm-lock.yaml
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: pnpm install --frozen-lockfile
+    - name: Propose ENS contenthash update
+      id: propose
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: node ./propose-update.mjs
+      env:
+        CID: ${{ inputs.cid }}
+        ENS_NAME: ${{ inputs.ens_name }}
+        RESOLVER_ADDRESS: ${{ inputs.resolver_address }}
+        SAFE_ADDRESS: ${{ inputs.safe_address }}
+        ENS_DELEGATE_PRIVATE_KEY: ${{ inputs.ens_delegate_private_key }}
+        RPC_URL: ${{ inputs.rpc_url }}
+        SAFE_API_KEY: ${{ inputs.safe_api_key }}
+        SAFE_TX_SERVICE_URL: ${{ inputs.safe_tx_service_url }}

--- a/actions/propose-ens-contenthash/action.yaml
+++ b/actions/propose-ens-contenthash/action.yaml
@@ -38,6 +38,15 @@ outputs:
   namehash:
     description: The ENS node hash of the name
     value: ${{ steps.propose.outputs.namehash }}
+  domain_hash:
+    description: EIP-712 domain hash of the Safe transaction (as shown in the Safe UI)
+    value: ${{ steps.propose.outputs.domain_hash }}
+  message_hash:
+    description: EIP-712 message hash of the Safe transaction (as shown in the Safe UI)
+    value: ${{ steps.propose.outputs.message_hash }}
+  data:
+    description: The setContenthash calldata sent to the resolver
+    value: ${{ steps.propose.outputs.data }}
 runs:
   using: composite
   steps:
@@ -96,6 +105,9 @@ runs:
         CONTENT_HASH: ${{ steps.propose.outputs.content_hash }}
         SAFE_TX_HASH: ${{ steps.propose.outputs.safe_tx_hash }}
         NAMEHASH: ${{ steps.propose.outputs.namehash }}
+        DOMAIN_HASH: ${{ steps.propose.outputs.domain_hash }}
+        MESSAGE_HASH: ${{ steps.propose.outputs.message_hash }}
+        DATA: ${{ steps.propose.outputs.data }}
       run: |-
         {
           echo "## Proposed ENS contenthash update"
@@ -105,9 +117,12 @@ runs:
           echo "| Field | Value |"
           echo "| --- | --- |"
           echo "| ENS name | \`${ENS_NAME}\` |"
-          echo "| Contenthash | \`${CONTENT_HASH}\` |"
-          echo "| Safe tx hash | \`${SAFE_TX_HASH}\` |"
-          echo "| Namehash | \`${NAMEHASH}\` |"
+          echo "| Node / Namehash | \`${NAMEHASH}\` |"
+          echo "| Content hash | \`${CONTENT_HASH}\` |"
+          echo "| Domain hash | \`${DOMAIN_HASH}\` |"
+          echo "| Message hash | \`${MESSAGE_HASH}\` |"
+          echo "| Safe TX hash | \`${SAFE_TX_HASH}\` |"
+          echo "| Data | \`${DATA}\` |"
           echo ""
-          echo "[Review in the Safe queue](https://app.safe.global/transactions/queue?safe=eth:${SAFE_ADDRESS})"
+          echo "### 🔗 [Review and sign the TX in the Safe queue](https://app.safe.global/transactions/queue?safe=eth:${SAFE_ADDRESS})"
         } >> "$GITHUB_STEP_SUMMARY"

--- a/actions/propose-ens-contenthash/package.json
+++ b/actions/propose-ens-contenthash/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "propose-ens-contenthash",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Propose an ENS setContenthash transaction to the owning Safe as a delegate",
+  "main": "propose-update.mjs",
+  "dependencies": {
+    "@ensdomains/content-hash": "3.1.1",
+    "@safe-global/api-kit": "4.2.0",
+    "@safe-global/protocol-kit": "7.2.0",
+    "viem": "2.53.1"
+  }
+}

--- a/actions/propose-ens-contenthash/package.json
+++ b/actions/propose-ens-contenthash/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "@ensdomains/content-hash": "3.1.1",
     "@safe-global/api-kit": "4.2.0",
-    "@safe-global/protocol-kit": "7.2.0",
     "viem": "2.53.1"
   }
 }

--- a/actions/propose-ens-contenthash/pnpm-lock.yaml
+++ b/actions/propose-ens-contenthash/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@safe-global/api-kit':
         specifier: 4.2.0
         version: 4.2.0
-      '@safe-global/protocol-kit':
-        specifier: 7.2.0
-        version: 7.2.0
       viem:
         specifier: 2.53.1
         version: 2.53.1

--- a/actions/propose-ens-contenthash/pnpm-lock.yaml
+++ b/actions/propose-ens-contenthash/pnpm-lock.yaml
@@ -1,0 +1,358 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@ensdomains/content-hash':
+        specifier: 3.1.1
+        version: 3.1.1
+      '@safe-global/api-kit':
+        specifier: 4.2.0
+        version: 4.2.0
+      '@safe-global/protocol-kit':
+        specifier: 7.2.0
+        version: 7.2.0
+      viem:
+        specifier: 2.53.1
+        version: 2.53.1
+
+packages:
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@ensdomains/content-hash@3.1.1':
+    resolution: {integrity: sha512-BKB3BtAtfDkSX3DOYsnnTlzAeM55bI0ze7UJhk8TzoxO5/4iHjgPoEHDzjgzCTYJoCOkpFPEDah+gl62e7HJjA==}
+    engines: {node: '>=18'}
+
+  '@multiformats/sha3@4.0.0':
+    resolution: {integrity: sha512-y/tB2RWyeIhUToaUIYkwZUtGqfGIa3kaTvAMVekvxWJUYaD7YLa7L6O8QYaOblxxc1MMobGwh63kS1NhocRQPw==}
+
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@peculiar/asn1-schema@2.8.0':
+    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
+  '@safe-global/api-kit@4.2.0':
+    resolution: {integrity: sha512-K65OCsIXq70y19qliu6cjpzCGYpOQ7gsBClLTxktDBNayk/G8udef23Di162jv4xWNf3KQ2+OX844/80g6wQ/A==}
+
+  '@safe-global/protocol-kit@7.2.0':
+    resolution: {integrity: sha512-ALYkC2UmtZRdz7nFf55d1lcXcrTAZNS1bNDnyeBqCCLVKy/VEFU6orAi1+hdQGaaxoAPx5KsqH6LmOC40RLvWQ==}
+
+  '@safe-global/safe-deployments@1.37.56':
+    resolution: {integrity: sha512-HF3ETre/KSP3nCOZ72XEbq5U56gOGgYLJ22LxOAnR8+YzMjzZ8cpnHpx5Z31Zt1xkUTGSCMi9XF950lJt6WbsQ==}
+
+  '@safe-global/safe-modules-deployments@3.0.4':
+    resolution: {integrity: sha512-aOFcv5tLPA/CS50Lknuo0QyB+zbwTCLKhnwzOoHRU9az6YDhB1q7ppq3jYk7+xhvzluhpPEfDd8HGKAOxHpLoQ==}
+
+  '@safe-global/types-kit@3.1.0':
+    resolution: {integrity: sha512-uI6lFV8wOji4rb7juu0/LRMND0rq2NWaqH4zFzE2FUjO8lTvbCT+/5W/+flUUfkcaqyLDlJ1OPjasa2bEakrbw==}
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  abitype@1.2.4:
+    resolution: {integrity: sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
+
+  js-sha3@0.9.3:
+    resolution: {integrity: sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==}
+
+  multiformats@13.4.2:
+    resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
+
+  multiformats@14.0.0:
+    resolution: {integrity: sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  viem@2.53.1:
+    resolution: {integrity: sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+snapshots:
+
+  '@adraffy/ens-normalize@1.11.1': {}
+
+  '@ensdomains/content-hash@3.1.1':
+    dependencies:
+      '@multiformats/sha3': 4.0.0
+      multiformats: 13.4.2
+
+  '@multiformats/sha3@4.0.0':
+    dependencies:
+      js-sha3: 0.9.3
+      multiformats: 14.0.0
+
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+    optional: true
+
+  '@noble/hashes@1.8.0': {}
+
+  '@peculiar/asn1-schema@2.8.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    optional: true
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@safe-global/api-kit@4.2.0':
+    dependencies:
+      '@safe-global/protocol-kit': 7.2.0
+      '@safe-global/types-kit': 3.1.0
+      node-fetch: 2.7.0
+      viem: 2.53.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@safe-global/protocol-kit@7.2.0':
+    dependencies:
+      '@safe-global/safe-deployments': 1.37.56
+      '@safe-global/safe-modules-deployments': 3.0.4
+      '@safe-global/types-kit': 3.1.0
+      abitype: 1.2.4
+      semver: 7.8.5
+      viem: 2.53.1
+    optionalDependencies:
+      '@noble/curves': 1.9.7
+      '@peculiar/asn1-schema': 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@safe-global/safe-deployments@1.37.56':
+    dependencies:
+      semver: 7.8.5
+
+  '@safe-global/safe-modules-deployments@3.0.4': {}
+
+  '@safe-global/types-kit@3.1.0':
+    dependencies:
+      abitype: 1.2.4
+    transitivePeerDependencies:
+      - typescript
+      - zod
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  abitype@1.2.3: {}
+
+  abitype@1.2.4: {}
+
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
+    optional: true
+
+  eventemitter3@5.0.1: {}
+
+  isows@1.0.7(ws@8.20.1):
+    dependencies:
+      ws: 8.20.1
+
+  js-sha3@0.9.3: {}
+
+  multiformats@13.4.2: {}
+
+  multiformats@14.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  ox@0.14.29:
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3
+      eventemitter3: 5.0.1
+    transitivePeerDependencies:
+      - zod
+
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  pvutils@1.1.5:
+    optional: true
+
+  semver@7.8.5: {}
+
+  tr46@0.0.3: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  viem@2.53.1:
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3
+      isows: 1.0.7(ws@8.20.1)
+      ox: 0.14.29
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  ws@8.20.1: {}

--- a/actions/propose-ens-contenthash/pnpm-lock.yaml
+++ b/actions/propose-ens-contenthash/pnpm-lock.yaml
@@ -1,11 +1,8 @@
 lockfileVersion: '9.0'
-
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
-
 importers:
-
   .:
     dependencies:
       '@ensdomains/content-hash':
@@ -20,65 +17,46 @@ importers:
       viem:
         specifier: 2.53.1
         version: 2.53.1
-
 packages:
-
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
-
   '@ensdomains/content-hash@3.1.1':
     resolution: {integrity: sha512-BKB3BtAtfDkSX3DOYsnnTlzAeM55bI0ze7UJhk8TzoxO5/4iHjgPoEHDzjgzCTYJoCOkpFPEDah+gl62e7HJjA==}
     engines: {node: '>=18'}
-
   '@multiformats/sha3@4.0.0':
     resolution: {integrity: sha512-y/tB2RWyeIhUToaUIYkwZUtGqfGIa3kaTvAMVekvxWJUYaD7YLa7L6O8QYaOblxxc1MMobGwh63kS1NhocRQPw==}
-
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
-
   '@noble/curves@1.9.1':
     resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
     engines: {node: ^14.21.3 || >=16}
-
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
-
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
-
   '@peculiar/asn1-schema@2.8.0':
     resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
-
   '@peculiar/utils@2.0.3':
     resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
-
   '@safe-global/api-kit@4.2.0':
     resolution: {integrity: sha512-K65OCsIXq70y19qliu6cjpzCGYpOQ7gsBClLTxktDBNayk/G8udef23Di162jv4xWNf3KQ2+OX844/80g6wQ/A==}
-
   '@safe-global/protocol-kit@7.2.0':
     resolution: {integrity: sha512-ALYkC2UmtZRdz7nFf55d1lcXcrTAZNS1bNDnyeBqCCLVKy/VEFU6orAi1+hdQGaaxoAPx5KsqH6LmOC40RLvWQ==}
-
   '@safe-global/safe-deployments@1.37.56':
     resolution: {integrity: sha512-HF3ETre/KSP3nCOZ72XEbq5U56gOGgYLJ22LxOAnR8+YzMjzZ8cpnHpx5Z31Zt1xkUTGSCMi9XF950lJt6WbsQ==}
-
   '@safe-global/safe-modules-deployments@3.0.4':
     resolution: {integrity: sha512-aOFcv5tLPA/CS50Lknuo0QyB+zbwTCLKhnwzOoHRU9az6YDhB1q7ppq3jYk7+xhvzluhpPEfDd8HGKAOxHpLoQ==}
-
   '@safe-global/types-kit@3.1.0':
     resolution: {integrity: sha512-uI6lFV8wOji4rb7juu0/LRMND0rq2NWaqH4zFzE2FUjO8lTvbCT+/5W/+flUUfkcaqyLDlJ1OPjasa2bEakrbw==}
-
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
-
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
-
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
-
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
     peerDependencies:
@@ -89,7 +67,6 @@ packages:
         optional: true
       zod:
         optional: true
-
   abitype@1.2.4:
     resolution: {integrity: sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==}
     peerDependencies:
@@ -100,28 +77,21 @@ packages:
         optional: true
       zod:
         optional: true
-
   asn1js@3.0.10:
     resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
     engines: {node: '>=12.0.0'}
-
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
-
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
-
   js-sha3@0.9.3:
     resolution: {integrity: sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==}
-
   multiformats@13.4.2:
     resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
-
   multiformats@14.0.0:
     resolution: {integrity: sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==}
-
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -130,7 +100,6 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-
   ox@0.14.29:
     resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
     peerDependencies:
@@ -138,25 +107,19 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
-
   pvutils@1.1.5:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
   viem@2.53.1:
     resolution: {integrity: sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==}
     peerDependencies:
@@ -164,13 +127,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
@@ -182,46 +142,35 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
 snapshots:
-
   '@adraffy/ens-normalize@1.11.1': {}
-
   '@ensdomains/content-hash@3.1.1':
     dependencies:
       '@multiformats/sha3': 4.0.0
       multiformats: 13.4.2
-
   '@multiformats/sha3@4.0.0':
     dependencies:
       js-sha3: 0.9.3
       multiformats: 14.0.0
-
   '@noble/ciphers@1.3.0': {}
-
   '@noble/curves@1.9.1':
     dependencies:
       '@noble/hashes': 1.8.0
-
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
     optional: true
-
   '@noble/hashes@1.8.0': {}
-
   '@peculiar/asn1-schema@2.8.0':
     dependencies:
       '@peculiar/utils': 2.0.3
       asn1js: 3.0.10
       tslib: 2.8.1
     optional: true
-
   '@peculiar/utils@2.0.3':
     dependencies:
       tslib: 2.8.1
     optional: true
-
   '@safe-global/api-kit@4.2.0':
     dependencies:
       '@safe-global/protocol-kit': 7.2.0
@@ -234,7 +183,6 @@ snapshots:
       - typescript
       - utf-8-validate
       - zod
-
   '@safe-global/protocol-kit@7.2.0':
     dependencies:
       '@safe-global/safe-deployments': 1.37.56
@@ -251,60 +199,44 @@ snapshots:
       - typescript
       - utf-8-validate
       - zod
-
   '@safe-global/safe-deployments@1.37.56':
     dependencies:
       semver: 7.8.5
-
   '@safe-global/safe-modules-deployments@3.0.4': {}
-
   '@safe-global/types-kit@3.1.0':
     dependencies:
       abitype: 1.2.4
     transitivePeerDependencies:
       - typescript
       - zod
-
   '@scure/base@1.2.6': {}
-
   '@scure/bip32@1.7.0':
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
-
   '@scure/bip39@1.6.0':
     dependencies:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
-
   abitype@1.2.3: {}
-
   abitype@1.2.4: {}
-
   asn1js@3.0.10:
     dependencies:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
       tslib: 2.8.1
     optional: true
-
   eventemitter3@5.0.1: {}
-
   isows@1.0.7(ws@8.20.1):
     dependencies:
       ws: 8.20.1
-
   js-sha3@0.9.3: {}
-
   multiformats@13.4.2: {}
-
   multiformats@14.0.0: {}
-
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-
   ox@0.14.29:
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -317,22 +249,16 @@ snapshots:
       eventemitter3: 5.0.1
     transitivePeerDependencies:
       - zod
-
   pvtsutils@1.3.6:
     dependencies:
       tslib: 2.8.1
     optional: true
-
   pvutils@1.1.5:
     optional: true
-
   semver@7.8.5: {}
-
   tr46@0.0.3: {}
-
   tslib@2.8.1:
     optional: true
-
   viem@2.53.1:
     dependencies:
       '@noble/curves': 1.9.1
@@ -347,12 +273,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
       - zod
-
   webidl-conversions@3.0.1: {}
-
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
   ws@8.20.1: {}

--- a/actions/propose-ens-contenthash/propose-update.mjs
+++ b/actions/propose-ens-contenthash/propose-update.mjs
@@ -7,6 +7,8 @@ import {
   namehash,
   encodeFunctionData,
   getAddress,
+  hashDomain,
+  hashStruct,
   hashTypedData,
   serializeSignature,
   zeroAddress,
@@ -15,6 +17,22 @@ import { privateKeyToAccount, sign } from "viem/accounts";
 import { encode as encodeContentHash } from "@ensdomains/content-hash";
 
 const CHAIN_ID = 1;
+
+// EIP-712 type of the Safe transaction struct (same across Safe >= 1.0.0).
+const SAFE_TX_TYPES = {
+  SafeTx: [
+    { name: "to", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "data", type: "bytes" },
+    { name: "operation", type: "uint8" },
+    { name: "safeTxGas", type: "uint256" },
+    { name: "baseGas", type: "uint256" },
+    { name: "gasPrice", type: "uint256" },
+    { name: "gasToken", type: "address" },
+    { name: "refundReceiver", type: "address" },
+    { name: "nonce", type: "uint256" },
+  ],
+};
 const cid = process.env.CID;
 const ensName = process.env.ENS_NAME;
 const resolverAddress = getAddress(process.env.RESOLVER_ADDRESS);
@@ -73,6 +91,12 @@ const includesChainId = atLeast130(safeInfo.version);
 const domain = includesChainId
   ? { chainId: CHAIN_ID, verifyingContract: safeAddress }
   : { verifyingContract: safeAddress };
+const eip712DomainType = includesChainId
+  ? [
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+    ]
+  : [{ name: "verifyingContract", type: "address" }];
 
 const safeTx = {
   to: resolverAddress,
@@ -89,22 +113,22 @@ const safeTx = {
 
 const safeTxHash = hashTypedData({
   domain,
-  types: {
-    SafeTx: [
-      { name: "to", type: "address" },
-      { name: "value", type: "uint256" },
-      { name: "data", type: "bytes" },
-      { name: "operation", type: "uint8" },
-      { name: "safeTxGas", type: "uint256" },
-      { name: "baseGas", type: "uint256" },
-      { name: "gasPrice", type: "uint256" },
-      { name: "gasToken", type: "address" },
-      { name: "refundReceiver", type: "address" },
-      { name: "nonce", type: "uint256" },
-    ],
-  },
+  types: SAFE_TX_TYPES,
   primaryType: "SafeTx",
   message: safeTx,
+});
+
+// The Safe UI shows these EIP-712 components when an owner reviews the tx:
+//   safeTxHash = keccak256(0x19 0x01 || domainHash || messageHash)
+// Logging them lets a reviewer cross-check against what their wallet displays.
+const domainHash = hashDomain({
+  domain,
+  types: { EIP712Domain: eip712DomainType },
+});
+const messageHash = hashStruct({
+  data: safeTx,
+  primaryType: "SafeTx",
+  types: SAFE_TX_TYPES,
 });
 
 // 5. Sign the hash with the delegate key. Signing the digest directly yields an
@@ -138,8 +162,12 @@ await apiKit.proposeTransaction({
 });
 
 console.log(`Proposed setContenthash for ${ensName}`);
-console.log(`  contenthash: ${encoded}`);
-console.log(`  safeTxHash:  ${safeTxHash}`);
+console.log(`  - Node / Namehash: ${node}`);
+console.log(`  - Content hash: ${encoded}`);
+console.log(`  - Domain hash:  ${domainHash}`);
+console.log(`  - Message hash: ${messageHash}`);
+console.log(`  - Safe TX hash:   ${safeTxHash}`);
+console.log(`  - Data:         ${data}`);
 console.log(
   `\nSafe queue url:    https://app.safe.global/transactions/queue?safe=eth:${safeAddress}`,
 );
@@ -148,7 +176,12 @@ console.log(
 if (process.env.GITHUB_OUTPUT) {
   appendFileSync(
     process.env.GITHUB_OUTPUT,
-    `safe_tx_hash=${safeTxHash}\ncontent_hash=${encoded}\nnamehash=${node}\n`,
+    `safe_tx_hash=${safeTxHash}\n` +
+      `content_hash=${encoded}\n` +
+      `namehash=${node}\n` +
+      `domain_hash=${domainHash}\n` +
+      `message_hash=${messageHash}\n` +
+      `data=${data}\n`,
   );
 }
 

--- a/actions/propose-ens-contenthash/propose-update.mjs
+++ b/actions/propose-ens-contenthash/propose-update.mjs
@@ -1,0 +1,100 @@
+// Encodes an IPFS CID as an ENS contenthash and proposes a `setContenthash`
+// transaction to the Safe that owns the ENS name, signed by a Safe delegate.
+// The delegate can only propose; Safe owners must confirm and execute.
+import { appendFileSync } from 'node:fs'
+import Safe from '@safe-global/protocol-kit'
+import SafeApiKit from '@safe-global/api-kit'
+import { namehash, encodeFunctionData, getAddress } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { mainnet } from 'viem/chains'
+import { encode as encodeContentHash } from '@ensdomains/content-hash'
+
+const required = (name) => {
+  const value = process.env[name]
+  if (!value) {
+    console.error(`Missing required input: ${name}`)
+    process.exit(1)
+  }
+  return value
+}
+
+const cid = required('CID')
+const ensName = required('ENS_NAME')
+const resolverAddress = getAddress(required('RESOLVER_ADDRESS'))
+const safeAddress = getAddress(required('SAFE_ADDRESS'))
+const privateKeyRaw = required('ENS_DELEGATE_PRIVATE_KEY')
+const privateKey = privateKeyRaw.startsWith('0x') ? privateKeyRaw : `0x${privateKeyRaw}`
+const rpcUrl = process.env.RPC_URL || mainnet.rpcUrls.default.http[0]
+const txServiceUrl = process.env.SAFE_TX_SERVICE_URL || ''
+const apiKey = process.env.SAFE_API_KEY || ''
+
+if (!txServiceUrl && !apiKey) {
+  console.error(
+    'Missing SAFE_API_KEY: an API key is required when using the hosted Safe Transaction Service. ' +
+      'Provide safe_api_key, or set safe_tx_service_url to a self-hosted Transaction Service.',
+  )
+  process.exit(1)
+}
+
+// 1. Encode the CID as an EIP-1577 ipfs contenthash. The library accepts both
+// CIDv0 (Qm...) and CIDv1 (bafy...) and normalizes them to the same value.
+const encoded = `0x${encodeContentHash('ipfs', cid)}`
+
+// 2. Build the setContenthash calldata against the resolver.
+const node = namehash(ensName)
+const data = encodeFunctionData({
+  abi: [
+    {
+      name: 'setContenthash',
+      type: 'function',
+      stateMutability: 'nonpayable',
+      inputs: [
+        { name: 'node', type: 'bytes32' },
+        { name: 'hash', type: 'bytes' },
+      ],
+      outputs: [],
+    },
+  ],
+  functionName: 'setContenthash',
+  args: [node, encoded],
+})
+
+// 3. Build the Safe transaction, signed by the delegate key.
+const protocolKit = await Safe.init({
+  provider: rpcUrl,
+  signer: privateKey,
+  safeAddress,
+})
+const safeTransaction = await protocolKit.createTransaction({
+  transactions: [{ to: resolverAddress, value: '0', data }],
+})
+const safeTxHash = await protocolKit.getTransactionHash(safeTransaction)
+const signature = await protocolKit.signHash(safeTxHash)
+
+// 4. Propose the transaction to the Safe Transaction Service as a delegate.
+const apiKit = new SafeApiKit({
+  chainId: 1n, // ENS lives only on mainnet
+  ...(txServiceUrl ? { txServiceUrl } : {}),
+  ...(apiKey ? { apiKey } : {}),
+})
+const senderAddress = privateKeyToAccount(privateKey).address
+await apiKit.proposeTransaction({
+  safeAddress,
+  safeTransactionData: safeTransaction.data,
+  safeTxHash,
+  senderAddress,
+  senderSignature: signature.data,
+  origin: 'hopr-workflows/propose-ens-contenthash',
+})
+
+console.log(`Proposed setContenthash for ${ensName}`)
+console.log(`  contenthash: ${encoded}`)
+console.log(`  safeTxHash:  ${safeTxHash}`)
+
+// 5. Emit outputs.
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `safe_tx_hash=${safeTxHash}\ncontent_hash=${encoded}\nnamehash=${node}\n`,
+  )
+}

--- a/actions/propose-ens-contenthash/propose-update.mjs
+++ b/actions/propose-ens-contenthash/propose-update.mjs
@@ -2,13 +2,19 @@
 // transaction to the Safe that owns the ENS name, signed by a Safe delegate.
 
 import { appendFileSync } from "node:fs";
-import Safe from "@safe-global/protocol-kit";
 import SafeApiKit from "@safe-global/api-kit";
-import { namehash, encodeFunctionData, getAddress } from "viem";
-import { privateKeyToAccount } from "viem/accounts";
-import { mainnet } from "viem/chains";
+import {
+  namehash,
+  encodeFunctionData,
+  getAddress,
+  hashTypedData,
+  serializeSignature,
+  zeroAddress,
+} from "viem";
+import { privateKeyToAccount, sign } from "viem/accounts";
 import { encode as encodeContentHash } from "@ensdomains/content-hash";
 
+const CHAIN_ID = 1;
 const cid = process.env.CID;
 const ensName = process.env.ENS_NAME;
 const resolverAddress = getAddress(process.env.RESOLVER_ADDRESS);
@@ -17,15 +23,18 @@ const privateKeyRaw = process.env.ENS_DELEGATE_PRIVATE_KEY;
 const privateKey = privateKeyRaw.startsWith("0x")
   ? privateKeyRaw
   : `0x${privateKeyRaw}`;
-const rpcUrl = process.env.RPC_URL || mainnet.rpcUrls.default.http[0];
 const txServiceUrl = process.env.SAFE_TX_SERVICE_URL || "";
+const origin =
+  process.env.TX_ORIGIN || "hopr-workflows/propose-ens-contenthash";
 const apiKey = process.env.SAFE_API_KEY || "";
 
 // 1. Encode the CID as an EIP-1577 ipfs contenthash. The library accepts both
 // CIDv0 (Qm...) and CIDv1 (bafy...) and normalizes them to the same value.
+console.log(`Encoding CID ${cid} as an ipfs contenthash...`);
 const encoded = `0x${encodeContentHash("ipfs", cid)}`;
 
 // 2. Build the setContenthash calldata against the resolver.
+console.log(`Building setContenthash calldata for ${ensName}...`);
 const node = namehash(ensName);
 const data = encodeFunctionData({
   abi: [
@@ -44,34 +53,88 @@ const data = encodeFunctionData({
   args: [node, encoded],
 });
 
-// 3. Build the Safe transaction, signed by the delegate key.
-const protocolKit = await Safe.init({
-  provider: rpcUrl,
-  signer: privateKey,
-  safeAddress,
-});
-const safeTransaction = await protocolKit.createTransaction({
-  transactions: [{ to: resolverAddress, value: "0", data }],
-});
-const safeTxHash = await protocolKit.getTransactionHash(safeTransaction);
-const signature = await protocolKit.signHash(safeTxHash);
-
-// 4. Propose the transaction to the Safe Transaction Service as a delegate.
+// 3. Read the Safe version and next nonce from the Transaction Service (no RPC).
+// getNextNonce accounts for transactions already queued but not yet executed.
+console.log(`Fetching Safe info and next nonce for ${safeAddress}...`);
 const apiKit = new SafeApiKit({
-  chainId: 1n,
+  chainId: BigInt(CHAIN_ID),
   ...(txServiceUrl ? { txServiceUrl } : {}),
   ...(apiKey ? { apiKey } : {}),
 });
-const senderAddress = privateKeyToAccount(privateKey).address;
+const safeInfo = await apiKit.getSafeInfo(safeAddress);
+const nonce = await apiKit.getNextNonce(safeAddress);
+console.log(`  Safe version: ${safeInfo.version}, next nonce: ${nonce}`);
 
+// 4. Compute the Safe EIP-712 transaction hash locally.
+// Safe contracts >= 1.3.0 include chainId in the EIP-712 domain; older ones
+// (which predate replay protection) use only the verifying contract.
+console.log(`Computing the EIP-712 safeTxHash...`);
+const includesChainId = atLeast130(safeInfo.version);
+const domain = includesChainId
+  ? { chainId: CHAIN_ID, verifyingContract: safeAddress }
+  : { verifyingContract: safeAddress };
+
+const safeTx = {
+  to: resolverAddress,
+  value: 0n,
+  data,
+  operation: 0, // CALL
+  safeTxGas: 0n,
+  baseGas: 0n,
+  gasPrice: 0n,
+  gasToken: zeroAddress,
+  refundReceiver: zeroAddress,
+  nonce: BigInt(nonce),
+};
+
+const safeTxHash = hashTypedData({
+  domain,
+  types: {
+    SafeTx: [
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "data", type: "bytes" },
+      { name: "operation", type: "uint8" },
+      { name: "safeTxGas", type: "uint256" },
+      { name: "baseGas", type: "uint256" },
+      { name: "gasPrice", type: "uint256" },
+      { name: "gasToken", type: "address" },
+      { name: "refundReceiver", type: "address" },
+      { name: "nonce", type: "uint256" },
+    ],
+  },
+  primaryType: "SafeTx",
+  message: safeTx,
+});
+
+// 5. Sign the hash with the delegate key. Signing the digest directly yields an
+// EIP-712 signature (v = 27/28), which is what the Safe contract expects.
+const senderAddress = privateKeyToAccount(privateKey).address;
+console.log(`Signing safeTxHash ${safeTxHash} as delegate ${senderAddress}...`);
+const signature = serializeSignature(
+  await sign({ hash: safeTxHash, privateKey }),
+);
+
+// 6. Propose the transaction to the Safe Transaction Service as a delegate.
 console.log(`Proposing TX...`);
 await apiKit.proposeTransaction({
   safeAddress,
-  safeTransactionData: safeTransaction.data,
+  safeTransactionData: {
+    to: resolverAddress,
+    value: "0",
+    data,
+    operation: 0,
+    safeTxGas: "0",
+    baseGas: "0",
+    gasPrice: "0",
+    gasToken: zeroAddress,
+    refundReceiver: zeroAddress,
+    nonce: Number(nonce),
+  },
   safeTxHash,
   senderAddress,
-  senderSignature: signature.data,
-  origin: "hopr-workflows/propose-ens-contenthash",
+  senderSignature: signature,
+  origin,
 });
 
 console.log(`Proposed setContenthash for ${ensName}`);
@@ -81,10 +144,19 @@ console.log(
   `\nSafe queue url:    https://app.safe.global/transactions/queue?safe=eth:${safeAddress}`,
 );
 
-// 5. Emit outputs.
+// 7. Emit outputs.
 if (process.env.GITHUB_OUTPUT) {
   appendFileSync(
     process.env.GITHUB_OUTPUT,
     `safe_tx_hash=${safeTxHash}\ncontent_hash=${encoded}\nnamehash=${node}\n`,
   );
+}
+
+// Returns true when the Safe contract version is >= 1.3.0 (chainId in domain).
+// Defaults to true for an unknown/missing version, matching modern deployments.
+function atLeast130(version) {
+  if (!version) return true;
+  const [major = 0, minor = 0] = version.split(".").map((n) => Number(n));
+  if (major !== 1) return major > 1;
+  return minor >= 3;
 }

--- a/actions/propose-ens-contenthash/propose-update.mjs
+++ b/actions/propose-ens-contenthash/propose-update.mjs
@@ -1,100 +1,102 @@
 // Encodes an IPFS CID as an ENS contenthash and proposes a `setContenthash`
 // transaction to the Safe that owns the ENS name, signed by a Safe delegate.
 // The delegate can only propose; Safe owners must confirm and execute.
-import { appendFileSync } from 'node:fs'
-import Safe from '@safe-global/protocol-kit'
-import SafeApiKit from '@safe-global/api-kit'
-import { namehash, encodeFunctionData, getAddress } from 'viem'
-import { privateKeyToAccount } from 'viem/accounts'
-import { mainnet } from 'viem/chains'
-import { encode as encodeContentHash } from '@ensdomains/content-hash'
+import { appendFileSync } from "node:fs";
+import Safe from "@safe-global/protocol-kit";
+import SafeApiKit from "@safe-global/api-kit";
+import { namehash, encodeFunctionData, getAddress } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { mainnet } from "viem/chains";
+import { encode as encodeContentHash } from "@ensdomains/content-hash";
 
 const required = (name) => {
-  const value = process.env[name]
+  const value = process.env[name];
   if (!value) {
-    console.error(`Missing required input: ${name}`)
-    process.exit(1)
+    console.error(`Missing required input: ${name}`);
+    process.exit(1);
   }
-  return value
-}
+  return value;
+};
 
-const cid = required('CID')
-const ensName = required('ENS_NAME')
-const resolverAddress = getAddress(required('RESOLVER_ADDRESS'))
-const safeAddress = getAddress(required('SAFE_ADDRESS'))
-const privateKeyRaw = required('ENS_DELEGATE_PRIVATE_KEY')
-const privateKey = privateKeyRaw.startsWith('0x') ? privateKeyRaw : `0x${privateKeyRaw}`
-const rpcUrl = process.env.RPC_URL || mainnet.rpcUrls.default.http[0]
-const txServiceUrl = process.env.SAFE_TX_SERVICE_URL || ''
-const apiKey = process.env.SAFE_API_KEY || ''
+const cid = required("CID");
+const ensName = required("ENS_NAME");
+const resolverAddress = getAddress(required("RESOLVER_ADDRESS"));
+const safeAddress = getAddress(required("SAFE_ADDRESS"));
+const privateKeyRaw = required("ENS_DELEGATE_PRIVATE_KEY");
+const privateKey = privateKeyRaw.startsWith("0x")
+  ? privateKeyRaw
+  : `0x${privateKeyRaw}`;
+const rpcUrl = process.env.RPC_URL || mainnet.rpcUrls.default.http[0];
+const txServiceUrl = process.env.SAFE_TX_SERVICE_URL || "";
+const apiKey = process.env.SAFE_API_KEY || "";
 
 if (!txServiceUrl && !apiKey) {
   console.error(
-    'Missing SAFE_API_KEY: an API key is required when using the hosted Safe Transaction Service. ' +
-      'Provide safe_api_key, or set safe_tx_service_url to a self-hosted Transaction Service.',
-  )
-  process.exit(1)
+    "Missing SAFE_API_KEY: an API key is required when using the hosted Safe Transaction Service. " +
+      "Provide safe_api_key, or set safe_tx_service_url to a self-hosted Transaction Service.",
+  );
+  process.exit(1);
 }
 
 // 1. Encode the CID as an EIP-1577 ipfs contenthash. The library accepts both
 // CIDv0 (Qm...) and CIDv1 (bafy...) and normalizes them to the same value.
-const encoded = `0x${encodeContentHash('ipfs', cid)}`
+const encoded = `0x${encodeContentHash("ipfs", cid)}`;
 
 // 2. Build the setContenthash calldata against the resolver.
-const node = namehash(ensName)
+const node = namehash(ensName);
 const data = encodeFunctionData({
   abi: [
     {
-      name: 'setContenthash',
-      type: 'function',
-      stateMutability: 'nonpayable',
+      name: "setContenthash",
+      type: "function",
+      stateMutability: "nonpayable",
       inputs: [
-        { name: 'node', type: 'bytes32' },
-        { name: 'hash', type: 'bytes' },
+        { name: "node", type: "bytes32" },
+        { name: "hash", type: "bytes" },
       ],
       outputs: [],
     },
   ],
-  functionName: 'setContenthash',
+  functionName: "setContenthash",
   args: [node, encoded],
-})
+});
 
 // 3. Build the Safe transaction, signed by the delegate key.
 const protocolKit = await Safe.init({
   provider: rpcUrl,
   signer: privateKey,
   safeAddress,
-})
+});
 const safeTransaction = await protocolKit.createTransaction({
-  transactions: [{ to: resolverAddress, value: '0', data }],
-})
-const safeTxHash = await protocolKit.getTransactionHash(safeTransaction)
-const signature = await protocolKit.signHash(safeTxHash)
+  transactions: [{ to: resolverAddress, value: "0", data }],
+});
+const safeTxHash = await protocolKit.getTransactionHash(safeTransaction);
+const signature = await protocolKit.signHash(safeTxHash);
 
 // 4. Propose the transaction to the Safe Transaction Service as a delegate.
 const apiKit = new SafeApiKit({
   chainId: 1n, // ENS lives only on mainnet
   ...(txServiceUrl ? { txServiceUrl } : {}),
   ...(apiKey ? { apiKey } : {}),
-})
-const senderAddress = privateKeyToAccount(privateKey).address
+});
+const senderAddress = privateKeyToAccount(privateKey).address;
 await apiKit.proposeTransaction({
   safeAddress,
   safeTransactionData: safeTransaction.data,
   safeTxHash,
   senderAddress,
   senderSignature: signature.data,
-  origin: 'hopr-workflows/propose-ens-contenthash',
-})
+  origin: "hopr-workflows/propose-ens-contenthash",
+});
 
-console.log(`Proposed setContenthash for ${ensName}`)
-console.log(`  contenthash: ${encoded}`)
-console.log(`  safeTxHash:  ${safeTxHash}`)
+console.log(`Proposed setContenthash for ${ensName}`);
+console.log(`  contenthash: ${encoded}`);
+console.log(`  safeTxHash:  ${safeTxHash}`);
 
 // 5. Emit outputs.
 if (process.env.GITHUB_OUTPUT) {
   appendFileSync(
     process.env.GITHUB_OUTPUT,
     `safe_tx_hash=${safeTxHash}\ncontent_hash=${encoded}\nnamehash=${node}\n`,
-  )
+  );
 }

--- a/actions/propose-ens-contenthash/propose-update.mjs
+++ b/actions/propose-ens-contenthash/propose-update.mjs
@@ -1,6 +1,6 @@
 // Encodes an IPFS CID as an ENS contenthash and proposes a `setContenthash`
 // transaction to the Safe that owns the ENS name, signed by a Safe delegate.
-// The delegate can only propose; Safe owners must confirm and execute.
+
 import { appendFileSync } from "node:fs";
 import Safe from "@safe-global/protocol-kit";
 import SafeApiKit from "@safe-global/api-kit";
@@ -9,34 +9,17 @@ import { privateKeyToAccount } from "viem/accounts";
 import { mainnet } from "viem/chains";
 import { encode as encodeContentHash } from "@ensdomains/content-hash";
 
-const required = (name) => {
-  const value = process.env[name];
-  if (!value) {
-    console.error(`Missing required input: ${name}`);
-    process.exit(1);
-  }
-  return value;
-};
-
-const cid = required("CID");
-const ensName = required("ENS_NAME");
-const resolverAddress = getAddress(required("RESOLVER_ADDRESS"));
-const safeAddress = getAddress(required("SAFE_ADDRESS"));
-const privateKeyRaw = required("ENS_DELEGATE_PRIVATE_KEY");
+const cid = process.env.CID;
+const ensName = process.env.ENS_NAME;
+const resolverAddress = getAddress(process.env.RESOLVER_ADDRESS);
+const safeAddress = getAddress(process.env.SAFE_ADDRESS);
+const privateKeyRaw = process.env.ENS_DELEGATE_PRIVATE_KEY;
 const privateKey = privateKeyRaw.startsWith("0x")
   ? privateKeyRaw
   : `0x${privateKeyRaw}`;
 const rpcUrl = process.env.RPC_URL || mainnet.rpcUrls.default.http[0];
 const txServiceUrl = process.env.SAFE_TX_SERVICE_URL || "";
 const apiKey = process.env.SAFE_API_KEY || "";
-
-if (!txServiceUrl && !apiKey) {
-  console.error(
-    "Missing SAFE_API_KEY: an API key is required when using the hosted Safe Transaction Service. " +
-      "Provide safe_api_key, or set safe_tx_service_url to a self-hosted Transaction Service.",
-  );
-  process.exit(1);
-}
 
 // 1. Encode the CID as an EIP-1577 ipfs contenthash. The library accepts both
 // CIDv0 (Qm...) and CIDv1 (bafy...) and normalizes them to the same value.
@@ -75,11 +58,13 @@ const signature = await protocolKit.signHash(safeTxHash);
 
 // 4. Propose the transaction to the Safe Transaction Service as a delegate.
 const apiKit = new SafeApiKit({
-  chainId: 1n, // ENS lives only on mainnet
+  chainId: 1n,
   ...(txServiceUrl ? { txServiceUrl } : {}),
   ...(apiKey ? { apiKey } : {}),
 });
 const senderAddress = privateKeyToAccount(privateKey).address;
+
+console.log(`Proposing TX...`);
 await apiKit.proposeTransaction({
   safeAddress,
   safeTransactionData: safeTransaction.data,
@@ -92,6 +77,9 @@ await apiKit.proposeTransaction({
 console.log(`Proposed setContenthash for ${ensName}`);
 console.log(`  contenthash: ${encoded}`);
 console.log(`  safeTxHash:  ${safeTxHash}`);
+console.log(
+  `\nSafe queue url:    https://app.safe.global/transactions/queue?safe=eth:${safeAddress}`,
+);
 
 // 5. Emit outputs.
 if (process.env.GITHUB_OUTPUT) {

--- a/actions/propose-ens-contenthash/propose-update.mjs
+++ b/actions/propose-ens-contenthash/propose-update.mjs
@@ -33,18 +33,18 @@ const SAFE_TX_TYPES = {
     { name: "nonce", type: "uint256" },
   ],
 };
-const cid = process.env.CID;
-const ensName = process.env.ENS_NAME;
-const resolverAddress = getAddress(process.env.RESOLVER_ADDRESS);
-const safeAddress = getAddress(process.env.SAFE_ADDRESS);
-const privateKeyRaw = process.env.ENS_DELEGATE_PRIVATE_KEY;
+const cid = process.env.cid;
+const ensName = process.env.ens_name;
+const resolverAddress = getAddress(process.env.resolver_address);
+const safeAddress = getAddress(process.env.safe_address);
+const privateKeyRaw = process.env.ens_delegate_private_key;
 const privateKey = privateKeyRaw.startsWith("0x")
   ? privateKeyRaw
   : `0x${privateKeyRaw}`;
-const txServiceUrl = process.env.SAFE_TX_SERVICE_URL || "";
+const txServiceUrl = process.env.safe_tx_service_url || "";
 const origin =
-  process.env.TX_ORIGIN || "hopr-workflows/propose-ens-contenthash";
-const apiKey = process.env.SAFE_API_KEY || "";
+  process.env.tx_origin || "hopr-workflows/propose-ens-contenthash";
+const apiKey = process.env.safe_api_key || "";
 
 // 1. Encode the CID as an EIP-1577 ipfs contenthash. The library accepts both
 // CIDv0 (Qm...) and CIDv1 (bafy...) and normalizes them to the same value.


### PR DESCRIPTION
Action from this PR takes an IPFS CID (e.g. produced by a previous workflow that publishes to IPFS), encodes it as an [EIP-1577](https://eips.ethereum.org/EIPS/eip-1577) `ipfs` contenthash, and **proposes** a `setContenthash` transaction to the [Safe](https://safe.global) multisig that owns the ENS name. The proposal is signed by a **Safe delegate** (`ENS_DELEGATE_PRIVATE_KEY`).

Exaple usage: https://github.com/gnosis/gnosis_vpn-docs/actions/runs/28014129627