### PR TITLE
fix: Remove a default nix cache

### DIFF
--- a/actions/nix-action/action.yaml
+++ b/actions/nix-action/action.yaml
@@ -13,7 +13,6 @@ inputs:
   cachix_cache_name:
     description: Cachix cache name (passed to setup-nix)
     required: false
-    default: hoprnet
   cachix_auth_token:
     description: Cachix authentication token (passed to setup-nix)
     required: false


### PR DESCRIPTION
The default nix cache it already comes determined by the repository name if it's not set. It cannot be hardcoded.