### PR TITLE
fix: cachix cache name

### DIFF
--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -15,6 +15,10 @@ on:
       source_branch:
         required: true
         type: string
+      cachix_cache_name:
+        required: false
+        type: string
+        description: Cachix cache name. Defaults to the caller repository name (passed to setup-nix).
       runner:
         required: false
         type: string
@@ -41,12 +45,13 @@ jobs:
       security-events: write
     steps:
       - name: Run zizmor
-        uses: hoprnet/hopr-workflows/actions/nix-action@fa71078959cf9f892185e8df16551720693a2cd1 # nix-action-v1
+        uses: hoprnet/hopr-workflows/actions/nix-action@ade4bbd75f7204255c61d19c23f67d3da221e7d2 # nix-action-v1.1.3
         env:
           GH_TOKEN: ${{ github.token }}
           NIX_CONFIG: "access-tokens = github.com=${{ github.token }}"
         with:
           source_branch: ${{ inputs.source_branch }}
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
           command: ${{ inputs.zizmor_command }}
           nix_path: ${{ inputs.nix_path }}

--- a/.github/workflows/checks.md
+++ b/.github/workflows/checks.md
@@ -22,6 +22,7 @@ jobs:
 | Name                 | Required | Default                                                      | Description                                 |
 | -------------------- | -------- | ------------------------------------------------------------ | ------------------------------------------- |
 | `source_branch`      | Yes      | —                                                            | Source branch to check out                  |
+| `cachix_cache_name`  | No       | `<repository name>`                                          | Cachix cache name.                          |
 | `pre_commit`         | No       | `true`                                                       | Enable pre-commit check                     |
 | `lint`               | No       | `true`                                                       | Enable lint check                           |
 | `deps`               | No       | `true`                                                       | Enable dependency check                     |

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -12,6 +12,10 @@ on:
       source_branch:
         required: true
         type: string
+      cachix_cache_name:
+        required: false
+        type: string
+        description: Cachix cache name. Defaults to the caller repository name (passed to setup-nix).
       pre_commit:
         required: false
         type: boolean
@@ -112,9 +116,10 @@ jobs:
     steps:
       - name: Run ${{ matrix.name }}
         if: matrix.enabled
-        uses: hoprnet/hopr-workflows/actions/nix-action@fa71078959cf9f892185e8df16551720693a2cd1 # nix-action-v1
+        uses: hoprnet/hopr-workflows/actions/nix-action@ade4bbd75f7204255c61d19c23f67d3da221e7d2 # nix-action-v1.1.3
         with:
           source_branch: ${{ inputs.source_branch }}
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
           command: ${{ matrix.command }}
           disable_sudo: ${{ inputs.disable_sudo }}

--- a/.github/workflows/tests.md
+++ b/.github/workflows/tests.md
@@ -47,6 +47,7 @@ jobs:
 | Name                           | Required | Default                           | Description                                                                     |
 | ------------------------------ | -------- | --------------------------------- | ------------------------------------------------------------------------------- |
 | `source_branch`                | Yes      | —                                 | Source branch to check out                                                      |
+| `cachix_cache_name`            | No       | `<repository name>`               | Cachix cache name                                                               |
 | `enable_unit_tests`            | No       | `true`                            | Enable unit tests                                                               |
 | `enable_integration_tests`     | No       | `false`                           | Enable integration tests                                                        |
 | `enable_nightly_tests`         | No       | `false`                           | Enable nightly tests                                                            |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,10 @@ on:
       source_branch:
         required: true
         type: string
+      cachix_cache_name:
+        required: false
+        type: string
+        description: Cachix cache name. Defaults to the caller repository name (passed to setup-nix).
       enable_unit_tests:
         required: false
         type: boolean
@@ -112,9 +116,10 @@ jobs:
       CI: "true"
     steps:
       - name: Run Unit
-        uses: hoprnet/hopr-workflows/actions/nix-action@fa71078959cf9f892185e8df16551720693a2cd1 # nix-action-v1
+        uses: hoprnet/hopr-workflows/actions/nix-action@ade4bbd75f7204255c61d19c23f67d3da221e7d2 # nix-action-v1.1.3
         with:
           source_branch: ${{ inputs.source_branch }}
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
           command: ${{ inputs.unit_test_command }}
           nix_path: ${{ inputs.nix_path }}
@@ -129,9 +134,10 @@ jobs:
       CI: "true"
     steps:
       - name: Run Integration
-        uses: hoprnet/hopr-workflows/actions/nix-action@fa71078959cf9f892185e8df16551720693a2cd1 # nix-action-v1
+        uses: hoprnet/hopr-workflows/actions/nix-action@ade4bbd75f7204255c61d19c23f67d3da221e7d2 # nix-action-v1.1.3
         with:
           source_branch: ${{ inputs.source_branch }}
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
           command: ${{ inputs.integration_test_command }}
           nix_path: ${{ inputs.nix_path }}
@@ -146,9 +152,10 @@ jobs:
       CI: "true"
     steps:
       - name: Run Unit Nightly
-        uses: hoprnet/hopr-workflows/actions/nix-action@fa71078959cf9f892185e8df16551720693a2cd1 # nix-action-v1
+        uses: hoprnet/hopr-workflows/actions/nix-action@ade4bbd75f7204255c61d19c23f67d3da221e7d2 # nix-action-v1.1.3
         with:
           source_branch: ${{ inputs.source_branch }}
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
           command: ${{ inputs.nightly_test_command }}
           nix_path: ${{ inputs.nix_path }}
@@ -162,9 +169,10 @@ jobs:
       contents: read
     steps:
       - name: Run Benchmark
-        uses: hoprnet/hopr-workflows/actions/nix-action@fa71078959cf9f892185e8df16551720693a2cd1 # nix-action-v1
+        uses: hoprnet/hopr-workflows/actions/nix-action@ade4bbd75f7204255c61d19c23f67d3da221e7d2 # nix-action-v1.1.3
         with:
           source_branch: ${{ inputs.source_branch }}
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
           command: ${{ inputs.benchmark_command }}
           nix_path: ${{ inputs.nix_path }}
@@ -183,9 +191,10 @@ jobs:
       CI: "true"
     steps:
       - name: Generate Unit report
-        uses: hoprnet/hopr-workflows/actions/nix-action@fa71078959cf9f892185e8df16551720693a2cd1 # nix-action-v1
+        uses: hoprnet/hopr-workflows/actions/nix-action@ade4bbd75f7204255c61d19c23f67d3da221e7d2 # nix-action-v1.1.3
         with:
           source_branch: ${{ inputs.source_branch }}
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
           command: ${{ inputs.unit_coverage_command }}
           nix_path: ${{ inputs.nix_path }}
@@ -213,9 +222,10 @@ jobs:
       CI: "true"
     steps:
       - name: Generate Integration report
-        uses: hoprnet/hopr-workflows/actions/nix-action@fa71078959cf9f892185e8df16551720693a2cd1 # nix-action-v1
+        uses: hoprnet/hopr-workflows/actions/nix-action@ade4bbd75f7204255c61d19c23f67d3da221e7d2 # nix-action-v1.1.3
         with:
           source_branch: ${{ inputs.source_branch }}
+          cachix_cache_name: ${{ inputs.cachix_cache_name }}
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
           command: ${{ inputs.integration_coverage_command }}
           nix_path: ${{ inputs.nix_path }}

--- a/actions/nix-action/README.md
+++ b/actions/nix-action/README.md
@@ -16,12 +16,12 @@ steps:
 
 ## Inputs
 
-| Input                 | Required | Default                       | Description                                       |
-| --------------------- | -------- | ----------------------------- | ------------------------------------------------- |
-| `command`             | Yes      | —                             | Shell command(s) to execute (supports multi-line) |
-| `source_branch`       | No       | `main`                        | Git branch to checkout                            |
-| `cachix_cache_name`   | No       | `hoprnet`                     | Cachix cache name (passed to setup-nix)           |
-| `cachix_auth_token`   | No       | `""`                          | Cachix authentication token (passed to setup-nix) |
-| `nix_path`            | No       | `nixpkgs=channel:nixos-26.05` | Nix path to use (passed to setup-nix)             |
-| `disable_sudo`        | No       | `"true"`                      | Disable sudo in harden-runner                     |
-| `persist_credentials` | No       | `"false"`                     | Persist git credentials after checkout            |
+| Input                 | Required | Default                       | Description                                               |
+| --------------------- | -------- | ----------------------------- | --------------------------------------------------------- |
+| `command`             | Yes      | —                             | Shell command(s) to execute (supports multi-line)         |
+| `source_branch`       | No       | `main`                        | Git branch to checkout                                    |
+| `cachix_cache_name`   | No       | `<repository name>`           | Cachix cache name. Defaults to the caller repository name |
+| `cachix_auth_token`   | No       | `""`                          | Cachix authentication token (passed to setup-nix)         |
+| `nix_path`            | No       | `nixpkgs=channel:nixos-26.05` | Nix path to use (passed to setup-nix)                     |
+| `disable_sudo`        | No       | `"true"`                      | Disable sudo in harden-runner                             |
+| `persist_credentials` | No       | `"false"`                     | Persist git credentials after checkout                    |

--- a/actions/nix-action/action.yaml
+++ b/actions/nix-action/action.yaml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: main
   cachix_cache_name:
-    description: Cachix cache name (passed to setup-nix)
+    description: Cachix cache name. Empty defaults to the caller repository name (passed to setup-nix)
     required: false
   cachix_auth_token:
     description: Cachix authentication token (passed to setup-nix)
@@ -43,7 +43,7 @@ runs:
         persist-credentials: ${{ inputs.persist_credentials }}
         ref: ${{ inputs.source_branch }}
     - name: Setup Nix
-      uses: hoprnet/hopr-workflows/actions/setup-nix@eedb4b7701714299852ca5243f1544b817653f33 # setup-nix-v2.0.1
+      uses: hoprnet/hopr-workflows/actions/setup-nix@ade4bbd75f7204255c61d19c23f67d3da221e7d2 # setup-nix-v2.0.2
       with:
         cachix_cache_name: ${{ inputs.cachix_cache_name }}
         cachix_auth_token: ${{ inputs.cachix_auth_token }}


### PR DESCRIPTION
The `cachix_cache_name` was not overwritable on every workflows. 
Also, the `test`, `check`, and `zizmor` workflows were using a version of the `nix-action` that had `hoprnet` as default `cachix_cache_name`, forcing all repository using the shared workflows to try to pull/push to the `hoprnet` cachix.