### PR TITLE
fix(generate-release-notes): use quote-safe whitespace trim instead of xargs

### DIFF
--- a/actions/generate-release-notes/generate-release-notes.sh
+++ b/actions/generate-release-notes/generate-release-notes.sh
@@ -42,18 +42,12 @@ fetch_merged_prs() {
     # Extract type and component from the title
     # Expected format: "type(component): description" or "type: description"
     if [[ $title == *":"* ]]; then
-      type=$(echo "${title}" | awk -F ':' '{print $1}' | awk -F '(' '{print $1}' | tr '[:upper:]' '[:lower:]' | xargs)
-      # Trim whitespace from type
-      type=${type## }
-      type=${type%% }
+      type=$(echo "${title}" | awk -F ':' '{print $1}' | awk -F '(' '{print $1}' | tr '[:upper:]' '[:lower:]' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
       if [[ $title == *"("*"):"* ]]; then
         # Remove type(component): from title
-        component=$(echo "${title}" | awk -F '(' '{print $2}' | awk -F ')' '{print $1}' | xargs)
+        component=$(echo "${title}" | awk -F '(' '{print $2}' | awk -F ')' '{print $1}' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
       fi
-      title=$(echo "${title}" | awk -F ':' '{print $2}')
-      # Trim whitespace from title
-      title=${title## }
-      title=${title%% }
+      title=$(echo "${title}" | awk -F ':' '{print $2}' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
     fi
 
     # Assign repository as component prefix to distinguish between repos


### PR DESCRIPTION
xargs interprets quote characters in its input, so any PR title with an unmatched quote (e.g. GitHub's default revert titles like 'Revert "chore: ..."') made it fail with "xargs: unmatched double quote". With set -euo pipefail this aborted the whole release workflow, as seen in the "Close release" workflow of gnosis/gnosis_vpn-client.

Replace the xargs trims with sed and drop the follow-up ${var## } / ${var%% } expansions, which only stripped a single space and are redundant now that sed trims all leading/trailing whitespace.