### PR TITLE
feat(release-version): add bump_version input to make the version bump optional

### DIFF
--- a/actions/release-version/README.md
+++ b/actions/release-version/README.md
@@ -129,8 +129,9 @@ The release process follows a two-branch model: `main` for active development an
 - `github_app_private_key`: GitHub App Private Key from the Bot with permission to make direct commits and releases
 - `draft`: Whether to create a draft release
 - `override`: Whether to allow updating an existing release for the target tag. When `false` (default), the action fails if the release already exists.
+- `bump_version`: Whether to bump the version file and push the bump commit after creating the release. When `true` (default), the version file is bumped right after the release is published. Set to `false` when the caller wants to defer the bump (e.g. run it in a separate job only after downstream publishing succeeded), so that a failed pipeline can be rolled back by just deleting the release and tag.
 
 ## Outputs
 
 - `current_version`: Current version released
-- `bump_version`: Version bumped
+- `bump_version`: Version bumped. Empty when the `bump_version` input is `false`.

--- a/actions/release-version/README.md
+++ b/actions/release-version/README.md
@@ -130,8 +130,9 @@ The release process follows a two-branch model: `main` for active development an
 - `draft`: Whether to create a draft release
 - `override`: Whether to allow updating an existing release for the target tag. When `false` (default), the action fails if the release already exists.
 - `bump_version`: Whether to bump the version file and push the bump commit after creating the release. When `true` (default), the version file is bumped right after the release is published. Set to `false` when the caller wants to defer the bump (e.g. run it in a separate job only after downstream publishing succeeded), so that a failed pipeline can be rolled back by just deleting the release and tag.
+- `continue_on_bump_version`: Whether to continue when the version bump step fails, instead of failing the whole action. When `true` (default), a failed bump is tolerated: the release stays published and the remaining steps (e.g. Zulip notification) still run, but the `bump_version` output is empty. Set to `false` to fail the action when the bump fails.
 
 ## Outputs
 
 - `current_version`: Current version released
-- `bump_version`: Version bumped. Empty when the `bump_version` input is `false`.
+- `bump_version`: Version bumped. Empty when the `bump_version` input is `false` or the bump step failed.

--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -29,6 +29,10 @@ inputs:
     description: Whether to bump the version file and push the bump commit after creating the release. Disable to defer the bump until the caller's pipeline has fully succeeded.
     required: false
     default: 'true'
+  continue_on_bump_version:
+    description: Whether to continue when the version bump step fails, instead of failing the whole action
+    required: false
+    default: 'true'
   cachix_cache_name:
     required: false
     description: "Cachix cache name to use"
@@ -186,6 +190,7 @@ runs:
     - name: Bump version
       id: bump
       if: inputs.bump_version == 'true'
+      continue-on-error: ${{ inputs.continue_on_bump_version == 'true' }}
       uses: hoprnet/hopr-workflows/actions/bump-version@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # bump-version-v2
       with:
         file: ${{ inputs.file }}

--- a/actions/release-version/action.yaml
+++ b/actions/release-version/action.yaml
@@ -25,6 +25,10 @@ inputs:
     description: Whether to allow updating an existing release for the same tag
     required: false
     default: 'false'
+  bump_version:
+    description: Whether to bump the version file and push the bump commit after creating the release. Disable to defer the bump until the caller's pipeline has fully succeeded.
+    required: false
+    default: 'true'
   cachix_cache_name:
     required: false
     description: "Cachix cache name to use"
@@ -181,6 +185,7 @@ runs:
         draft: ${{ inputs.draft }}
     - name: Bump version
       id: bump
+      if: inputs.bump_version == 'true'
       uses: hoprnet/hopr-workflows/actions/bump-version@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # bump-version-v2
       with:
         file: ${{ inputs.file }}


### PR DESCRIPTION
Allows callers to skip the built-in version bump and run it themselves after their whole release pipeline succeeded, so a failed release can be fully rolled back by deleting the release and tag (no leftover 'ci: Bump to version' commit on the branch).

Default 'true' keeps current behavior for existing consumers.