### PR TITLE
feat: disable pre-commit-hook for the auto version bump

### DIFF
--- a/actions/bump-version/README.md
+++ b/actions/bump-version/README.md
@@ -2,6 +2,7 @@
 
 This action modifies the `Cargo.toml` file to bump the `version` attribute based on the parameter `release_type`.
 It also commits the change on the `${{ github.ref_name}}` branch. If the branch is protected, then it's recommended to add a bypass rule for the `bot` user.
+The automated version-bump commit bypasses repository-local Git hooks; validation is expected to run in the repository's CI checks.
 
 ## Usage
 

--- a/actions/bump-version/README.md
+++ b/actions/bump-version/README.md
@@ -2,7 +2,7 @@
 
 This action modifies the `Cargo.toml` file to bump the `version` attribute based on the parameter `release_type`.
 It also commits the change on the `${{ github.ref_name}}` branch. If the branch is protected, then it's recommended to add a bypass rule for the `bot` user.
-The automated version-bump commit bypasses repository-local Git hooks; validation is expected to run in the repository's CI checks.
+Repository-local Git hooks still run for the automated version-bump commit when configured. A missing `.pre-commit-config.yaml` does not block the commit or push.
 
 ## Usage
 

--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -113,6 +113,12 @@ runs:
         else
           echo "commit_files=${{ inputs.file }}" | tee -a "$GITHUB_OUTPUT"
         fi
+    - name: Disable Git hooks for automated version bump
+      shell: bash
+      run: |
+        hooks_dir="$RUNNER_TEMP/empty-git-hooks"
+        mkdir -p "$hooks_dir"
+        git config --local core.hooksPath "$hooks_dir"
     - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
       with:
         add: '${{ steps.versions.outputs.commit_files }}'

--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -113,13 +113,9 @@ runs:
         else
           echo "commit_files=${{ inputs.file }}" | tee -a "$GITHUB_OUTPUT"
         fi
-    - name: Disable Git hooks for automated version bump
-      shell: bash
-      run: |
-        hooks_dir="$RUNNER_TEMP/empty-git-hooks"
-        mkdir -p "$hooks_dir"
-        git config --local core.hooksPath "$hooks_dir"
     - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
+      env:
+        PRE_COMMIT_ALLOW_NO_CONFIG: "1"
       with:
         add: '${{ steps.versions.outputs.commit_files }}'
         new_branch: ${{ github.ref_name }}


### PR DESCRIPTION
Allow the bump version job to run without the pre-commit-hook file.