### PR TITLE
fix(deps): ignore nix-lib in dependabot nix updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
       timezone: "UTC"
     cooldown:
       default-days: 7
+    ignore:
+      # nix-lib uses version-pinned refs (github:hoprnet/nix-lib/vX.Y.Z) that
+      # Dependabot compares incorrectly and proposes as a downgrade. Version
+      # upgrades are managed manually alongside breaking API changes.
+      - dependency-name: "nix-lib"
     groups:
       nix-flake-inputs:
         patterns:


### PR DESCRIPTION
Dependabot's nix ecosystem support rewrites version-pinned `flake.nix` refs and proposed a downgrade of `nix-lib` from `v1.3.0` to `v1.2.0` (hoprnet/hoprnet#8281), breaking tests that rely on `runNextest` added in v1.3.0. Adds an ignore rule so Dependabot skips `nix-lib` version pins; upgrades remain manual alongside any breaking API changes.