### PR TITLE
fix: Let coverage jobs respect workflow cancellation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -181,7 +181,7 @@ jobs:
     name: Coverage / Unit
     needs: [unit-test]
     if: >-
-      always() && inputs.enable_unit_coverage && (needs['unit-test'].result == 'success' || needs['unit-test'].result == 'skipped') && (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
+      !cancelled() && inputs.enable_unit_coverage && (needs['unit-test'].result == 'success' || needs['unit-test'].result == 'skipped') && (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
     runs-on: ${{ inputs.runner_unit }}
     timeout-minutes: ${{ inputs.coverage_timeout }}
     permissions:
@@ -212,7 +212,7 @@ jobs:
     name: Coverage / Integration
     needs: [integration-test]
     if: >-
-      always() && inputs.enable_integration_coverage && (needs['integration-test'].result == 'success' || needs['integration-test'].result == 'skipped') && (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
+      !cancelled() && inputs.enable_integration_coverage && (needs['integration-test'].result == 'success' || needs['integration-test'].result == 'skipped') && (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
     runs-on: ${{ inputs.runner_integration || inputs.runner_unit }}
     timeout-minutes: ${{ inputs.coverage_timeout }}
     permissions:


### PR DESCRIPTION
## Summary

`Coverage / Unit` and `Coverage / Integration` used `always()` in their job-level `if` condition. `always()` doesn't just mean "run even if a previous job failed" — it also overrides workflow *cancellation*, so these jobs kept running to completion even after `cancel-in-progress` requested a cancel (e.g. when a new commit is pushed to the same PR).

Observed impact on a blokli PR: a stale run's `Coverage / Unit` job stayed stuck on its "Generate Unit report" step long after the newer commit's run was queued, delaying the new run from starting since both share the same concurrency group.

Replaced `always()` with `!cancelled()` in both jobs — this keeps the intended behavior (still run when the dependency job was skipped or succeeded, even if some earlier job in the workflow failed) while correctly stopping the job when the workflow itself is cancelled.

## Test plan

- [x] `actionlint` / `pinact` pre-commit hooks pass
- [ ] Verify on a real PR that cancelling a run now cancels the coverage jobs promptly instead of running them to completion